### PR TITLE
Handle pager opening

### DIFF
--- a/lisp/ein-kernel.el
+++ b/lisp/ein-kernel.el
@@ -585,7 +585,8 @@ Example::
         for text = (plist-get p :text)
         for source = (plist-get p :source)
         if (member source '("IPython.kernel.zmq.page.page"
-                            "IPython.zmq.page.page"))
+                            "IPython.zmq.page.page"
+                            "page"))
         do (when (not (equal (ein:trim text) ""))
              (ein:events-trigger
               events 'open_with_text.Pager (list :text text)))


### PR DESCRIPTION
Before, this fork has a small regression: Typing 'thing?' into the shell does not open the pager. This small change fixes this small regression.
