### PR TITLE
point URI references to millejoh.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,4 +48,4 @@ does it for you for all EIN dependencies.
 
 Please consider putting log and backtrace in your bug report.
 Follow the instruction in the manual:
-http://tkf.github.com/emacs-ipython-notebook/#reporting-issue
+http://millejoh.github.com/emacs-ipython-notebook/#reporting-issue

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -164,7 +164,7 @@ _gh-pages-assert-repo:
 gh-pages-clone:
 	rm -rf build/html
 	git clone --branch gh-pages \
-		git@github.com:tkf/emacs-ipython-notebook.git \
+		git@github.com:millejoh/emacs-ipython-notebook.git \
 		build/html
 
 gh-pages-pull: _gh-pages-assert-repo

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -10,7 +10,7 @@ evaluation, object inspection and code completion.  These features can be
 accessed anywhere in Emacs and improve Python code editing and reading in Emacs.
 
 .. _`Emacs IPython Notebook (EIN)`:
-  https://github.com/tkf/emacs-ipython-notebook
+  https://github.com/millejoh/emacs-ipython-notebook
 
 .. _SLIME: http://common-lisp.net/project/slime/
 
@@ -44,9 +44,9 @@ Links:
   <https://github.com/millejoh/emacs-ipython-notebook/wiki>`_
 
   + `Screenshots
-    <https://github.com/tkf/emacs-ipython-notebook/wiki/Screenshots>`_
+    <https://github.com/millejoh/emacs-ipython-notebook/wiki/Screenshots>`_
   + `Tips
-    <https://github.com/tkf/emacs-ipython-notebook/wiki/Tips>`_
+    <https://github.com/millejoh/emacs-ipython-notebook/wiki/Tips>`_
 
 * `Downloads
   <https://github.com/millejoh/emacs-ipython-notebook/tags>`_
@@ -112,7 +112,7 @@ Requirements
   emacs initialization file add
 
   ``(add-hook 'ein:connect-mode-hook 'ein:jedi-setup)``
-  
+
 Also, EIN heavily relies on standard Emacs libraries including EWOC,
 EIEIO and json.el.  EIN is currently tested against Emacs 23.3 and 24.3.
 It is known to work in Emacs 23.2, 24.1 and 24.2.
@@ -495,7 +495,7 @@ web client.  See `emacslisp.py`_ for more details.
    6
 
 .. _`emacslisp.py`:
-  https://github.com/tkf/emacs-ipython-notebook/blob/master/tools/emacslisp.py
+  https://github.com/millejoh/emacs-ipython-notebook/blob/master/tools/emacslisp.py
 
 
 Reporting issues
@@ -575,7 +575,7 @@ v0.5
 ----
 
 * Add support for stdin channel. This mean getpass.getpass() and the ipdb work in no
-  
+
 v0.4
 ----
 
@@ -588,7 +588,7 @@ v0.4
 * Restore support for heading level cells with nbformat v4 notebooks.
 * New (buggy) pytools function `ein:pytools-export-buffer` for using nbconvert on a notebook
   buffer.
-  
+
 v0.3
 ----
 
@@ -739,4 +739,3 @@ Indices and tables
 
 * :ref:`genindex`
 * :ref:`search`
-


### PR DESCRIPTION
This just cleans up some links that pointed to the old TKF repository.

I have also migrated the old wiki if that is useful (some of these changes point to your new wiki).
https://github.com/flamingbear/emacs-ipython-notebook/wiki

