### PR TITLE
Important fix, there is a `g` where there shouldn't be.

### DIFF
--- a/lisp/ein-kernel.el
+++ b/lisp/ein-kernel.el
@@ -651,7 +651,6 @@ Example::
                      (setf (ein:$kernel-running kernel) nil))
                  (when callback (apply callback cbargs)))
                kernel callback cbargs))))
-g
 
 ;; Reply handlers.
 


### PR DESCRIPTION
This goes into the MELPA version, making it unusable.