### PR TITLE
Fix symbol ein-direct is void

### DIFF
--- a/lisp/ein-ac.el
+++ b/lisp/ein-ac.el
@@ -88,18 +88,18 @@ Maximum number of cache to store."
 (defun ein:ac-direct-get-matches ()
   (ein:ac-chunk-candidates-from-list ein:ac-direct-matches))
 
-(ac-define-source ein-direct
-  '((candidates . ein:ac-direct-get-matches)
-    (requires . 0)
-    (prefix . ein:ac-chunk-beginning)
-    (symbol . "s")))
+(eval '(ac-define-source ein-direct
+                         '((candidates . ein:ac-direct-get-matches)
+                           (requires . 0)
+                           (prefix . ein:ac-chunk-beginning)
+                           (symbol . "s"))))
 
-(ac-define-source ein-async
-  '((candidates . ein:ac-direct-get-matches)
-    (requires . 0)
-    (prefix . ein:ac-chunk-beginning)
-    (init . ein:ac-request-in-background)
-    (symbol . "c")))
+(eval '(ac-define-source ein-async
+                         '((candidates . ein:ac-direct-get-matches)
+                           (requires . 0)
+                           (prefix . ein:ac-chunk-beginning)
+                           (init . ein:ac-request-in-background)
+                           (symbol . "c"))))
 
 (define-obsolete-function-alias 'ac-complete-ein-cached 'ac-complete-ein-async
   "0.2.1")


### PR DESCRIPTION
When setting ein to use `auto-complete` in either basic or superpack
mode I get this ein-direct symbol is void error.

I don't know if you want PRs done against dev or master, so I've chosen freely.

The exact error message is `ein-jedi:31:1:Error: Symbol's value as variable is void: ein-direct`