### PR TITLE
Update notebooklist url functions to work with jupyter

### DIFF
--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -113,14 +113,14 @@ To suppress popup, you can pass a function `ein:do-nothing' as CALLBACK."
 
 (defun ein:notebooklist-url (url-or-port version &optional path)
   (let ((base-path (cond ((= version 2) "api/notebooks")
-                         ((= version 3) "api/contents"))))
+                         ((>= version 3) "api/contents"))))
     (if path
         (ein:url url-or-port base-path (or path ""))
       (ein:url url-or-port base-path))))
 
 (defun ein:notebooklist-new-url (url-or-port version &optional path)
   (let ((base-path (cond ((= version 2) "api/notebooks")
-                         ((= version 3) "api/contents"))))
+                         ((>= version 3) "api/contents"))))
     (ein:log 'info "New notebook. Port: %s, Path: %s" url-or-port path)
     (if (and path (not (string= path "")))
         (ein:url url-or-port base-path path)


### PR DESCRIPTION
Previously, base-path would be nil when version was 4 (corresponding
to the current jupyter release).