### PR TITLE
autoload ein:notebooklist-login (issue#154)

### DIFF
--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -732,6 +732,7 @@ FIMXE: document how to use `ein:notebooklist-find-file-callback'
 
 ;;; Login
 
+;;;###autoload
 (defun ein:notebooklist-login (url-or-port password)
   "Login to IPython notebook server."
   (interactive (list (ein:notebooklist-ask-url-or-port)


### PR DESCRIPTION
trivial change to make logging in easier (https://github.com/millejoh/emacs-ipython-notebook/issues/154)