### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,8 +181,9 @@ Usage
 =====
 
 1. Install from MELPA_.
-   Put Emacs lisp ``ein*.el`` files and Python file ``ein.py`` in your
-   load path.  See `online documentation`_ for more information.
+   For manual install, put Emacs lisp ``ein*.el`` files and Python file
+   ``ein.py`` in your load path. See `online documentation`_ for more
+   information.
 
 2. Start the `Jupyter notebook server`_.
 


### PR DESCRIPTION
Changed description of manual installation in "usage" section.
Made it more explicit that you only need to manually put files in
the load path when not using MELPA.