### PR TITLE
Add guard to allow for links in older org-mode versions

### DIFF
--- a/lisp/ein-org.el
+++ b/lisp/ein-org.el
@@ -102,8 +102,9 @@ node `(org) External links' and Info node `(org) Search options'"
 ;;;###autoload
 (eval-after-load "org"
   '(progn
-     (org-link-set-parameters "ipynb" :follow #'ein:org-open)
-     ;;(org-add-link-type "ipynb" :follow 'ein:org-open)
+     (if (fboundp 'org-link-set-parameters)
+         (org-link-set-parameters "ipynb" :follow #'ein:org-open)
+       (org-add-link-type "ipynb" :follow 'ein:org-open))
      (add-hook 'org-store-link-functions 'ein:org-store-link)))
 ;; The above expression is evaluated via loaddef file.  At the moment,
 ;; org.el nor ein-org.el need not be loaded.  When org-mode is used,


### PR DESCRIPTION
Something like this ought to fix #184