### PR TITLE
ein:get-kernel works in edit-cell-mode

### DIFF
--- a/lisp/ein-core.el
+++ b/lisp/ein-core.el
@@ -265,7 +265,8 @@ but can operate in different contexts."
   (ein:generic-getter '(ein:get-kernel--notebook
                         ein:get-kernel--worksheet
                         ein:get-kernel--shared-output
-                        ein:get-kernel--connect)))
+                        ein:get-kernel--connect
+                        ein:get-kernel--worksheet-in-edit-cell)))
 
 (defun ein:get-kernel-or-error ()
   (or (ein:get-kernel)

--- a/lisp/ein-worksheet.el
+++ b/lisp/ein-worksheet.el
@@ -940,6 +940,13 @@ in the history."
 (defun ein:get-kernel--worksheet ()
   (when (ein:worksheet-p ein:%worksheet%) (oref ein:%worksheet% :kernel)))
 
+;; in edit-cell-mode, worksheet is bound as src--ws
+;; used by ein:get-kernel as a last option so completion, tooltips
+;; work in edit-cell-mode
+(defun ein:get-kernel--worksheet-in-edit-cell ()
+  "Get kernel when in edit-cell-mode."
+  (when (ein:worksheet-p ein:src--ws) (oref ein:src--ws :kernel)))
+
 (defun ein:get-cell-at-point--worksheet ()
   (ein:worksheet-get-current-cell :noerror t))
 


### PR DESCRIPTION
Modify ein:get-kernel so it can retrieve the kernel from the local
worksheet variable in edit-cell-mode. This is done so that functions
such as ein:completer-complete and tooltips / inline help are
availeble to be bound by the user.