### PR TITLE
ein:notebook-save-notebook: run before-save-hook in the notebook buffer

### DIFF
--- a/lisp/ein-notebook.el
+++ b/lisp/ein-notebook.el
@@ -871,7 +871,8 @@ This is equivalent to do ``C-c`` in the console program."
 
 (defun ein:notebook-save-notebook (notebook retry &optional callback cbargs)
   (condition-case err
-      (run-hooks 'before-save-hook)
+      (with-current-buffer (ein:notebook-buffer notebook)
+        (run-hooks 'before-save-hook))
     (error (ein:log 'warn "Error running save hooks: '%s'. I will still try to save the notebook." (error-message-string err))))
   (let ((content (ein:content-from-notebook notebook)))
     (ein:events-trigger (ein:$notebook-events notebook)


### PR DESCRIPTION
fixes https://github.com/millejoh/emacs-ipython-notebook/issues/173