### PR TITLE
require ein-contents-api in ein-jupyterhub

### DIFF
--- a/lisp/ein-jupyterhub.el
+++ b/lisp/ein-jupyterhub.el
@@ -32,6 +32,7 @@
 (require 'request-deferred)
 (require 'deferred)
 (require 'ein-query)
+(require 'ein-contents-api)
 
 
 (defun ein:jupyterhub-api-url (url-or-port command &rest args)


### PR DESCRIPTION
I was getting a void variable on ein:content-query-timeout. Requiring the file that defines it solves the problem.