### PR TITLE
Search backward instead of forward for connection info

### DIFF
--- a/lisp/ein-jupyter.el
+++ b/lisp/ein-jupyter.el
@@ -89,14 +89,14 @@ session, along with the login token."
   (assert (processp %ein:jupyter-server-session%) t "Jupyter server has not started!")
   (condition-case err
       (with-current-buffer (process-buffer %ein:jupyter-server-session%) ;;ein:jupyter-server-buffer-name
-        (goto-char (point-min))
-        (re-search-forward "\\(https?://.*:[0-9]+\\)/\\?token=\\(.*\\)" nil)
+        (goto-char (point-max))
+        (re-search-backward "\\(https?://.*:[0-9]+\\)/\\?token=\\(.*\\)" nil)
         (let ((url-or-port (match-string 1))
               (token (match-string 2)))
           (list url-or-port token)))
     (error (with-current-buffer (process-buffer %ein:jupyter-server-session%)
-             (goto-char (point-min))
-             (if (re-search-forward "\\(https?://.*:[0-9]+\\)" nil t)
+             (goto-char (point-max))
+             (if (re-search-backward "\\(https?://.*:[0-9]+\\)" nil t)
                  (list (match-string 1) nil)
                (list nil nil))))))
 


### PR DESCRIPTION
Since all jupyter servers append output to the same buffer `*ein:jupyter-server*` we should make the function `ein:jupyter-server-conn-info` start at the end and search backward for the most recent port and token.

Otherwise the same port and token will be returned each time and we keep logging into the first server, ignoring subsequent servers.