### PR TITLE
Put "All Opened Notebooks" above directory list

### DIFF
--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -594,8 +594,9 @@ Only difference is the if type file section is added for ipy3, and
 the api-version line is present for ipy2."
     (widget-insert "\n------------------------------------------\n\n")
     (let (
-	  ;; This next line only if ipy < 3
-          (api-version (ein:$notebooklist-api-version ein:%notebooklist%))
+	  (when (< ipy-version 3)
+            (api-version (ein:$notebooklist-api-version ein:%notebooklist%))
+	  )
 	  (sessions (make-hash-table :test 'equal))
 	  )
 
@@ -625,25 +626,29 @@ the api-version line is present for ipy2."
                      "Dir")
                     (widget-insert " : " name)
                     (widget-insert "\n"))
-	  ;; This section only if ipy >= 3 (the file part)
-          if (string= type "file")
-          do (progn (widget-create
-                     'link
-                     :notify (lexical-let ((urlport urlport)
-                                           (path path))
-                               (lambda (&rest ignore)
-                                 (ein:notebooklist-open-file urlport path)))
-                     "Open")
-                    (widget-insert " ")
-                    (widget-create
-                     'link
-                     :notify (lexical-let ((path path))
-                               (lambda (&rest ignore)
-                                 (message "[EIN]: NBlist delete file command. Implement me!")))
-                     "Delete")
-                    (widget-insert " : " name)
-                    (widget-insert "\n"))
-	  ;; Below this ipy2 and ipy3 are identical
+
+	  (when (>= ipy-version 3)
+	    (
+	      ;; This section only if ipy >= 3 (the file part)
+              if (string= type "file")
+              do (progn (widget-create
+                         'link
+                         :notify (lexical-let ((urlport urlport)
+                                               (path path))
+                                   (lambda (&rest ignore)
+                                     (ein:notebooklist-open-file urlport path)))
+                         "Open")
+                        (widget-insert " ")
+                        (widget-create
+                         'link
+                         :notify (lexical-let ((path path))
+                                   (lambda (&rest ignore)
+                                     (message "[EIN]: NBlist delete file command. Implement me!")))
+                         "Delete")
+                        (widget-insert " : " name)
+                        (widget-insert "\n"))
+	  ))
+
           if (string= type "notebook")
           do (progn (widget-create
                      'link

--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -24,7 +24,7 @@
 
 ;;  The rendering is split into a function for python2 and one for
 ;;  python3, ein:notebooklist-render-ipy2 and
-;;  ein:notebooklist-render-ipy2.
+;;  ein:notebooklist-render.
 
 ;;; Code:
 
@@ -541,7 +541,7 @@ Notebook list data is passed via the buffer local variable
   (ein:notebooklist-mode)
   (widget-setup))
 
- (defun ein:notebooklist--order-data (nblist-data)
+(defun ein:notebooklist--order-data (nblist-data)
   "Try to sanely sort the notebooklist data for the current path."
   (let* ((groups (-group-by #'(lambda (x) (plist-get x :type))
                             nblist-data))
@@ -635,7 +635,8 @@ Notebook list data is passed via the buffer local variable
 
   (defun render-directory ()
     "Render directory (for ipython>=3."
-    (widget-insert "\n------------------------------------------\n\n")    (let ((sessions (make-hash-table :test 'equal)))
+    (widget-insert "\n------------------------------------------\n\n")
+    (let ((sessions (make-hash-table :test 'equal)))
     (ein:content-query-sessions sessions (ein:$notebooklist-url-or-port ein:%notebooklist%) t)
     (sit-for 0.2) ;; FIXME: What is the optimum number here?
     (loop for note in (ein:notebooklist--order-data (ein:$notebooklist-data ein:%notebooklist%))
@@ -732,10 +733,10 @@ Notebook list data is passed via the buffer local variable
   (ein:notebooklist-mode)
   (widget-setup))
 
-;;; ### autoload
+;;;###autoload
 (defun ein:notebooklist-list-notebooks ()
-  "Return a list of notebook path (NBPATH).
-Each element NBPATH is a string of the format \"URL-OR-PORT/NOTEBOOK-NAME\"."
+  "Return a list of notebook path (NBPATH).  Each element NBPATH
+is a string of the format \"URL-OR-PORT/NOTEBOOK-NAME\"."
   (apply #'append
          (loop for nblist in (ein:notebooklist-list)
                for url-or-port = (ein:$notebooklist-url-or-port nblist)

--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -589,20 +589,25 @@ Notebook list data is passed via the buffer local variable
 
 
   (defun render-directory ()
-    "Render directory (for ipython>=3."
+    "Render directory (for ipython>=3.
+Only difference is the if type file section is added for ipy3, and
+the api-version line is present for ipy2."
     (widget-insert "\n------------------------------------------\n\n")
-    (let ((sessions (make-hash-table :test 'equal)))
+    (let (
+	  (sessions (make-hash-table :test 'equal))
+	  )
 
-    (ein:content-query-sessions sessions (ein:$notebooklist-url-or-port ein:%notebooklist%) t)
+    (ein:content-query-sessions sessions
+        (ein:$notebooklist-url-or-port ein:%notebooklist%) t)
+
     (sit-for 0.2) ;; FIXME: What is the optimum number here?
-    (loop for note in (ein:notebooklist--order-data (ein:$notebooklist-data ein:%notebooklist%))
+    (loop for note in
+          (ein:notebooklist--order-data (ein:$notebooklist-data ein:%notebooklist%))
+
           for urlport = (ein:$notebooklist-url-or-port ein:%notebooklist%)
           for name = (plist-get note :name)
           for path = (plist-get note :path)
-          ;; (cond ((= 2 api-version)
-          ;;        (plist-get note :path))
-          ;;       ((= 3 api-version)
-          ;;        (ein:get-actual-path (plist-get note :path))))
+
           for type = (plist-get note :type)
           for opened-notebook-maybe = (ein:notebook-get-opened-notebook urlport path)
           do (widget-insert " ")
@@ -635,6 +640,7 @@ Notebook list data is passed via the buffer local variable
                      "Delete")
                     (widget-insert " : " name)
                     (widget-insert "\n"))
+	  ;; Below this ipy2 and ipy3 are identical
           if (string= type "notebook")
           do (progn (widget-create
                      'link
@@ -674,18 +680,26 @@ Notebook list data is passed via the buffer local variable
   )
 
  (defun render-directory-ipy2 ()
-  (let ((api-version (ein:$notebooklist-api-version ein:%notebooklist%))
-        (sessions (make-hash-table :test 'equal)))
+   "Render directory for ipython2.
+Only difference is the if type file section is added for ipy3, and
+the api-version line is present for ipy2."
+"
+  (let (
+	(api-version (ein:$notebooklist-api-version ein:%notebooklist%))
+        (sessions (make-hash-table :test 'equal))
+	)
 
-    (ein:content-query-sessions sessions (ein:$notebooklist-url-or-port ein:%notebooklist%) t)
-    (loop for note in (ein:$notebooklist-data ein:%notebooklist%)
+    (ein:content-query-sessions sessions
+        (ein:$notebooklist-url-or-port ein:%notebooklist%) t)
+
+    (sit-for 0.2) ;; FIXME: What is the optimum number here?
+    (loop for note in
+	  (ein:$notebooklist-data ein:%notebooklist%)
+
 	  for urlport = (ein:$notebooklist-url-or-port ein:%notebooklist%)
 	  for name = (plist-get note :name)
 	  for path = (plist-get note :path)
-	  ;; (cond ((= 2 api-version)
-	  ;;        (plist-get note :path))
-	  ;;       ((= 3 api-version)
-	  ;;        (ein:get-actual-path (plist-get note :path))))
+
 	  for type = (plist-get note :type)
 	  for opened-notebook-maybe = (ein:notebook-get-opened-notebook urlport path)
 	  do (widget-insert " ")
@@ -701,6 +715,7 @@ Notebook list data is passed via the buffer local variable
                "Dir")
               (widget-insert " : " name)
               (widget-insert "\n"))
+	  ;; Below this ipy2 and ipy3 are identical
 	  if (string= type "notebook")
 	  do (progn (widget-create
 		     'link

--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -40,6 +40,17 @@
 (require 'deferred)
 (require 'dash)
 
+
+(defcustom ein:notebook-list-render-order
+  '(render-header
+    render-opened-notebooks
+    render-directory)
+  "Order of notebook list sections.
+Must contain render-header, render-opened-notebooks, and render-directory."
+  :group 'ein
+  :type 'list
+)
+
 (defcustom ein:notebooklist-first-open-hook nil
   "Hooks to run when the notebook list is opened at first time.
 
@@ -714,9 +725,9 @@ Notebook list data is passed via the buffer local variable
     (erase-buffer))
   (remove-overlays)
 
-  (render-header)
-  (render-opened-notebooks)
-  (render-directory)
+  (mapc (lambda (fn) (apply fn '()))
+     ein:notebook-list-render-order
+    )
 
   (ein:notebooklist-mode)
   (widget-setup))

--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -448,7 +448,7 @@ Notebook list data is passed via the buffer local variable
   (remove-overlays)
 
   (render-header-ipy2)
-  (render-directory)
+  (render-directory-ipy2)
 
   (ein:notebooklist-mode)
   (widget-setup)
@@ -589,28 +589,20 @@ Notebook list data is passed via the buffer local variable
 
 
   (defun render-directory ()
-    "Render directory (for ipython>=3.
-Only difference is the if type file section is added for ipy3, and
-the api-version line is present for ipy2."
+    "Render directory (for ipython>=3."
     (widget-insert "\n------------------------------------------\n\n")
-    (let (
-	  (when (< ipy-version 3)
-            (api-version (ein:$notebooklist-api-version ein:%notebooklist%))
-	  )
-	  (sessions (make-hash-table :test 'equal))
-	  )
+    (let ((sessions (make-hash-table :test 'equal)))
 
-    (ein:content-query-sessions sessions
-        (ein:$notebooklist-url-or-port ein:%notebooklist%) t)
-
+    (ein:content-query-sessions sessions (ein:$notebooklist-url-or-port ein:%notebooklist%) t)
     (sit-for 0.2) ;; FIXME: What is the optimum number here?
-    (loop for note in
-          (ein:notebooklist--order-data (ein:$notebooklist-data ein:%notebooklist%))
-
+    (loop for note in (ein:notebooklist--order-data (ein:$notebooklist-data ein:%notebooklist%))
           for urlport = (ein:$notebooklist-url-or-port ein:%notebooklist%)
           for name = (plist-get note :name)
           for path = (plist-get note :path)
-
+          ;; (cond ((= 2 api-version)
+          ;;        (plist-get note :path))
+          ;;       ((= 3 api-version)
+          ;;        (ein:get-actual-path (plist-get note :path))))
           for type = (plist-get note :type)
           for opened-notebook-maybe = (ein:notebook-get-opened-notebook urlport path)
           do (widget-insert " ")
@@ -626,29 +618,23 @@ the api-version line is present for ipy2."
                      "Dir")
                     (widget-insert " : " name)
                     (widget-insert "\n"))
-
-	  (when (>= ipy-version 3)
-	    (
-	      ;; This section only if ipy >= 3 (the file part)
-              if (string= type "file")
-              do (progn (widget-create
-                         'link
-                         :notify (lexical-let ((urlport urlport)
-                                               (path path))
-                                   (lambda (&rest ignore)
-                                     (ein:notebooklist-open-file urlport path)))
-                         "Open")
-                        (widget-insert " ")
-                        (widget-create
-                         'link
-                         :notify (lexical-let ((path path))
-                                   (lambda (&rest ignore)
-                                     (message "[EIN]: NBlist delete file command. Implement me!")))
-                         "Delete")
-                        (widget-insert " : " name)
-                        (widget-insert "\n"))
-	  ))
-
+          if (string= type "file")
+          do (progn (widget-create
+                     'link
+                     :notify (lexical-let ((urlport urlport)
+                                           (path path))
+                               (lambda (&rest ignore)
+                                 (ein:notebooklist-open-file urlport path)))
+                     "Open")
+                    (widget-insert " ")
+                    (widget-create
+                     'link
+                     :notify (lexical-let ((path path))
+                               (lambda (&rest ignore)
+                                 (message "[EIN]: NBlist delete file command. Implement me!")))
+                     "Delete")
+                    (widget-insert " : " name)
+                    (widget-insert "\n"))
           if (string= type "notebook")
           do (progn (widget-create
                      'link
@@ -686,6 +672,70 @@ the api-version line is present for ipy2."
 
     )
   )
+
+ (defun render-directory-ipy2 ()
+  (let ((api-version (ein:$notebooklist-api-version ein:%notebooklist%))
+        (sessions (make-hash-table :test 'equal)))
+
+    (ein:content-query-sessions sessions (ein:$notebooklist-url-or-port ein:%notebooklist%) t)
+    (loop for note in (ein:$notebooklist-data ein:%notebooklist%)
+	  for urlport = (ein:$notebooklist-url-or-port ein:%notebooklist%)
+	  for name = (plist-get note :name)
+	  for path = (plist-get note :path)
+	  ;; (cond ((= 2 api-version)
+	  ;;        (plist-get note :path))
+	  ;;       ((= 3 api-version)
+	  ;;        (ein:get-actual-path (plist-get note :path))))
+	  for type = (plist-get note :type)
+	  for opened-notebook-maybe = (ein:notebook-get-opened-notebook urlport path)
+	  do (widget-insert " ")
+	  if (string= type "directory")
+	  do (progn (widget-create
+               'link
+               :notify (lexical-let ((urlport urlport)
+                                     (path name))
+                         (lambda (&rest ignore)
+                           (ein:notebooklist-open urlport
+                                                  (ein:url (ein:$notebooklist-path ein:%notebooklist%)
+                                                           path))))
+               "Dir")
+              (widget-insert " : " name)
+              (widget-insert "\n"))
+	  if (string= type "notebook")
+	  do (progn (widget-create
+		     'link
+		     :notify (lexical-let ((name name)
+					   (path path))
+			       (lambda (&rest ignore)
+				 (run-at-time 3 nil
+					      #'ein:notebooklist-reload ein:%notebooklist%) ;; TODO using deferred better?
+				 (ein:notebooklist-open-notebook
+				  ein:%notebooklist% path)))
+		     "Open")
+		    (widget-insert " ")
+		    (when (gethash path sessions)
+		      (widget-create
+		       'link
+		       :notify (lexical-let ((session (car (gethash path sessions)))
+					     (nblist ein:%notebooklist%))
+				 (lambda (&rest ignore)
+				   (run-at-time 1 nil
+						#'ein:notebooklist-reload
+						ein:%notebooklist%)
+				   (ein:kernel-kill (make-ein:$kernel :url-or-port (ein:$notebooklist-url-or-port nblist)
+								      :session-id session))))
+		       "Stop")
+		      (widget-insert " "))
+		    (widget-create
+		     'link
+		     :notify (lexical-let ((path path))
+			       (lambda (&rest ignore)
+				 (ein:notebooklist-delete-notebook-ask
+				  path)))
+		     "Delete")
+		    (widget-insert " : " name)
+		    (widget-insert "\n"))))
+ )
 
  (defun ein:notebooklist-render ()
   "Render notebook list widget.


### PR DESCRIPTION
See [this issue](https://github.com/millejoh/emacs-ipython-notebook/issues/281).  

Hi!  I made the order customizable with `ein:notebook-list-render-order`.  Also this only changes things for python>=3, so I didn't touch the `ein:notebooklist-render-ipy2` function.  

With opened notebooks above the directory list, it looks like:

```
Jupyter v5 Notebook list (http://127.0.0.1:8888)

 | [Home] | [edward] | [notebooks] |

[New Notebook] [Reload List] [Open In Browser]

Create New Notebooks Using Kernel: 
( ) Julia 0.3.6
( ) Python 3
( ) Python 2 - Points to shims
( ) Julia 0.3.6
( ) R
( ) Julia 0.6.2


---------- All Opened Notebooks ----------

[Open][Close] : *ein: http://127.0.0.1:8888/linear_mixed_effects_models.ipynb*

------------------------------------------

 [Dir] : data
 [Open] [Delete] : supervised_classification.ipynb
 [Open] [Delete] : iclr2017.ipynb
 [Open] [Delete] : gan.ipynb
 [Open] [Stop] [Delete] : linear_mixed_effects_models.ipynb
 [Open] [Delete] : getting_started.ipynb
```

@millejoh is this basically an OK way to do this?  Should I do the same thing for `ein:notebooklist-render-ipy2`?  Thanks!  