### PR TITLE
Add no-popup argument to ein:jupyter-server-start

### DIFF
--- a/lisp/ein-jupyter.el
+++ b/lisp/ein-jupyter.el
@@ -101,7 +101,7 @@ session, along with the login token."
                (list nil nil))))))
 
 ;;;###autoload
-(defun ein:jupyter-server-login-and-open ()
+(defun ein:jupyter-server-login-and-open (&optional no-popup)
   "Log in and open a notebooklist buffer for a running jupyter notebook server.
 
 Determine if there is a running jupyter server (started via a
@@ -116,14 +116,14 @@ via a call to `ein:notebooklist-open'."
           (progn
             (ein:notebooklist-login url-or-port token)
             (sit-for 1.0) ;; FIXME: Do better!
-            (ein:notebooklist-open url-or-port))
+            (ein:notebooklist-open url-or-port nil no-popup))
         (if url-or-port
             (ein:notebooklist-open url-or-port)
           (ein:log 'info "Could not determine port nor login info for jupyter server."))))))
 
 
 ;;;###autoload
-(defun ein:jupyter-server-start (server-cmd-path notebook-directory &optional no-login-after-start-p)
+(defun ein:jupyter-server-start (server-cmd-path notebook-directory &optional no-login-after-start-p no-popup)
   "Start the jupyter notebook server at the given path.
 
 This command opens an asynchronous process running the jupyter
@@ -191,7 +191,7 @@ the log of the running jupyter server."
                 (ein:jupyter-server-stop t))
             (ein:force-ipython-version-check)
             (unless no-login-p
-              (ein:jupyter-server-login-and-open))))))))
+              (ein:jupyter-server-login-and-open no-popup))))))))
 
 ;;;###autoload
 

--- a/lisp/ein-jupyter.el
+++ b/lisp/ein-jupyter.el
@@ -166,6 +166,7 @@ the log of the running jupyter server."
                                  (ein:jupyter-server-stop t)))
   (message "Starting notebook server in directory: %s" notebook-directory)
   (lexical-let ((no-login-after-start-p no-login-after-start-p)
+                (no-popup no-popup)
                 (proc (ein:jupyter-server--run ein:jupyter-server-buffer-name
                                                *ein:last-jupyter-command*
                                                *ein:last-jupyter-directory*)))


### PR DESCRIPTION
# Motivation

I want to start a jupyter notebook server through EIN on startup. To this end I put a call to `ein:jupyter-server-start` in my init file. However `ein:jupyter-server-start` unconditionally pops up the notebook list on success, which makes for a jarring startup experience.

# Description of Change

This pull request adds an optional `no-popup` argument to `ein:jupyter-server-start` so that it can be called like

```
(ein:jupyter-server-start ... :no-popup)
```

# Comments

I was able to verify this works in a edebug session, but get

```
deferred error : (void-variable no-popup)
```

when I try and run it directly.

Perhaps I need to re-compile EIN? I tried to do a `C-u 0 M-x byte-recompile-directory` as per [this stack overflow post](https://stackoverflow.com/a/1217249/2323999) but got

```
Done (Total of 0 files compiled, 55 skipped)
```

so nothing happens. What am I missing?