### PR TITLE
Fix token authentication

### DIFF
--- a/lisp/ein-jupyter.el
+++ b/lisp/ein-jupyter.el
@@ -90,7 +90,7 @@ session, along with the login token."
   (condition-case err
       (with-current-buffer (process-buffer %ein:jupyter-server-session%) ;;ein:jupyter-server-buffer-name
         (goto-char (point-max))
-        (re-search-backward "\\(https?://.*:[0-9]+\\)/\\?token=\\(.*\\)" nil)
+        (re-search-backward "\\(https?://.*:[0-9]+\\)/\\?token=\\([[:alnum:]]*\\)" nil)
         (let ((url-or-port (match-string 1))
               (token (match-string 2)))
           (list url-or-port token)))


### PR DESCRIPTION
With the current version of the Jupyter notebook, extracting the login token from the server logs fails. This can be reproduced by using Jupyter notebook 5.5.0 with the default configuration and calling `ein:jupyter-server-start`.

That happens because jupyter/notebook@53cbd52 causes the token GET-parameter to be appended to the URL twice. An easy fix is to modify the regex so that it matches just the first token value.