### PR TITLE
make timestamp format customizable and default to ISO 8601

### DIFF
--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -244,8 +244,7 @@ refresh the notebook connection."
 
 (defcustom ein:notebooklist-date-format "%x"
   "The format spec for date in notebooklist mode.
-Should be either a string (passed to `format-time-string')
-or a function (called on the date)."
+See `ein:format-time-string'."
   :type '(or string function)
   :group 'ein)
 
@@ -663,9 +662,7 @@ Notebook list data is passed via the buffer local variable
 (defun ein:format-nbitem-data (name last-modified)
   (let ((dt (date-to-time last-modified)))
     (format "%-40s%+20s" name
-            (cl-etypecase ein:notebooklist-date-format
-              (string (format-time-string ein:notebooklist-date-format dt))
-              (function (funcall ein:notebooklist-date-format dt))))))
+            (ein:format-time-string ein:notebooklist-date-format dt))))
 
 (defun render-directory (ipy-at-least-3)
   "Render directory.

--- a/lisp/ein-timestamp.el
+++ b/lisp/ein-timestamp.el
@@ -28,6 +28,12 @@
 (require 'ein-kernel)
 (require 'ein-cell)
 
+(defcustom ein:timestamp-format "%FT%T"
+  "The format spec for timestamps.
+See `ein:format-time-string'."
+  :type '(or string function)
+  :group 'ein)
+
 (defun ein:timestamp--shell-reply-hook (msg-type header content metadata)
   (when (string-equal msg-type "execute_reply")
     (let ((start-time (plist-get metadata :started))
@@ -50,12 +56,12 @@
     (if-let ((etime (plist-get (ein:cell-metadata cell) :execute-time)))
         (let ((start-time (date-to-time (first etime)))
               (end-time (date-to-time (second etime))))
-          (ein:insert-read-only (format "Last executed %s in %ss\n\n"
-                                        (current-time-string start-time)
-                                        (float-time (time-subtract end-time start-time))))))))
+          (ein:insert-read-only
+           (format "Last executed %s in %ss\n\n"
+                   (ein:format-time-string ein:timestamp-format start-time)
+                   (float-time (time-subtract end-time start-time))))))))
 
 (add-hook 'ein:on-shell-reply-functions 'ein:timestamp--shell-reply-hook)
 (add-hook 'ein:on-execute-reply-functions 'ein:timestamp--execute-reply-hook)
 
 (provide 'ein-timestamp)
-

--- a/lisp/ein-utils.el
+++ b/lisp/ein-utils.el
@@ -264,7 +264,7 @@ See: http://api.jquery.com/jQuery.ajax/"
 number of lines is less than `nlines' then just return the string."
   (if nlines
     (let ((lines (split-string string "[\n]")))
-      (if (> (length lines) nlines) 
+      (if (> (length lines) nlines)
           (ein:join-str "\n" (append (butlast lines (- (length lines) nlines))
                                      (list "...")))
         string))
@@ -552,6 +552,14 @@ Make TIMEOUT-SECONDS larger \(default 5) to wait longer before timeout."
                 do (sleep-for 0.05))
     (warn "Timeout"))
   (ein:log 'debug "WAIT-UNTIL end"))
+
+(defun ein:format-time-string (format time)
+  "Apply format to time.
+If `format' is a string, call `format-time-string',
+otherwise it should be a function, which is called on `time'."
+  (cl-etypecase format
+    (string (format-time-string format time))
+    (function (funcall format time))))
 
 
 ;;; Emacs utilities


### PR DESCRIPTION
add ein:format-time-string and use it for both ein:timestamp-format
and ein:notebooklist-date-format