### PR TITLE
now that auto-complete is an official dependency, we can require it unconditionally

### DIFF
--- a/lisp/ein-ac.el
+++ b/lisp/ein-ac.el
@@ -26,7 +26,7 @@
 ;;; Code:
 
 (eval-when-compile (require 'cl))
-(require 'auto-complete nil t)
+(require 'auto-complete)
 
 (require 'ein-core)
 (eval-when-compile (require 'ein-notebook)
@@ -81,18 +81,18 @@
 (defun ein:ac-direct-get-matches ()
  (ein:ac-chunk-candidates-from-list ein:ac-direct-matches))
 
-(eval '(ac-define-source ein-direct
-                         '((candidates . ein:ac-direct-get-matches)
-                           (requires . 0)
-                           (prefix . ein:ac-chunk-beginning)
-                           (symbol . "s"))))
+(ac-define-source ein-direct
+  '((candidates . ein:ac-direct-get-matches)
+    (requires . 0)
+    (prefix . ein:ac-chunk-beginning)
+    (symbol . "s")))
 
-(eval '(ac-define-source ein-async
-                         '((candidates . ein:ac-direct-get-matches)
-                           (requires . 0)
-                           (prefix . ein:ac-chunk-beginning)
-                           (init . ein:ac-request-in-background)
-                           (symbol . "c"))))
+(ac-define-source ein-async
+  '((candidates . ein:ac-direct-get-matches)
+    (requires . 0)
+    (prefix . ein:ac-chunk-beginning)
+    (init . ein:ac-request-in-background)
+    (symbol . "c")))
 
 (define-obsolete-function-alias 'ac-complete-ein-cached 'ac-complete-ein-async
   "0.2.1")

--- a/lisp/ein-completer.el
+++ b/lisp/ein-completer.el
@@ -35,8 +35,7 @@
 (require 'ein-kernel)
 
 (defun ein:completer-choose ()
-  (when (require 'auto-complete nil t)
-    (require 'ein-ac))
+  (require 'ein-ac)
   (cond
    ((and (or (eql ein:completion-backend 'ein:use-ac-backend)
              (eql ein:completion-backend 'ein:use-ac-jedi-backend))

--- a/lisp/ein-connect.el
+++ b/lisp/ein-connect.el
@@ -31,7 +31,7 @@
 ;;; Code:
 
 (require 'eieio)
-(eval-when-compile (require 'auto-complete nil t))
+(eval-when-compile (require 'auto-complete))
 
 (require 'ein-notebook)
 

--- a/lisp/ein-notebook.el
+++ b/lisp/ein-notebook.el
@@ -35,7 +35,7 @@
 
 (eval-when-compile (require 'cl))
 (require 'ewoc)
-(eval-when-compile (require 'auto-complete nil t))
+(eval-when-compile (require 'auto-complete))
 
 (require 'ein-core)
 (require 'ein-classes)


### PR DESCRIPTION
this allows us to get rid of the ugly eval on a macro

generally speaking, `eval` should be avoided in lisp; if you are using it, you might be doing something wrong.