### PR TITLE
Fix `ein:object-at-point' in `subword-mode'

### DIFF
--- a/lisp/ein-utils.el
+++ b/lisp/ein-utils.el
@@ -125,11 +125,11 @@ before previous opening parenthesis."
                 "\\s-\\|\n\\|\\.")
     (save-excursion
       (with-syntax-table ein:dotty-syntax-table
-        (ein:aif (thing-at-point 'word)
+        (ein:aif (thing-at-point 'symbol)
             it
           (unless (looking-at "(")
             (search-backward "(" (point-at-bol) t))
-          (thing-at-point 'word))))))
+          (thing-at-point 'symbol))))))
 
 (defun ein:object-at-point-or-error ()
   (or (ein:object-at-point) (error "No object found at the point")))


### PR DESCRIPTION
This fixes the `ein:object-at-point` function so it works in `subword-mode`. 

Original issue here:

https://github.com/millejoh/emacs-ipython-notebook/issues/313

-------------------------------------------------------------------------

When `subword-mode` is enabled, the `(ein:object-at-point)` function fails after dots. For example, let's say `|` is the cursor and `subword-mode` is enabled: 

Calling `(ein:object-at-point)` on this: `tf|` returns `"tf"`. This is correct.

Calling `(ein:object-at-point)` on this: `tf.|` returns `nil`. It should return `"tf."`.

Calling `(ein:object-at-point)` on this: `tf.nn|` returns `nil`. It should return `"tf.nn"`.

One side effect of this is that `company-mode` suggestions stop working after dots in `subword-mode`. For example:

```
import tensorflow as tf
tf.n|
```

Will not provide suggestions from the ein completion engine. 

I tried changing the `(ein:object-at-point)` function to return the *symbol* at point, rather than the word, and this fixed the problem. Would this produce any undesirable side effects? If not, I can submit a pull request.