### PR TITLE
Don't strip existing headers in `ein:query-prepare-header`

### DIFF
--- a/lisp/ein-query.el
+++ b/lisp/ein-query.el
@@ -128,7 +128,8 @@ _xsrf argument."
          (cookies (request-cookie-alist (url-host parsed-url)
                                        "/" securep)))
     (ein:aif (assoc-string "_xsrf" cookies)
-        (setq settings (plist-put settings :headers (list (cons "X-XSRFTOKEN" (cdr it))))))
+        (setq settings (plist-put settings :headers (append (plist-get settings :headers)
+                                                            (list (cons "X-XSRFTOKEN" (cdr it)))))))
     (ein:aif (ein:jupyterhub-url-p (format "http://%s:%s" (url-host parsed-url) (url-port parsed-url)))
         (progn
           (unless (string-equal (ein:$jh-conn-url it)


### PR DESCRIPTION
This change fixes the issue where notebook being saved is sent to Jupyter with `Content-Type: application/x-www-form-urlencoded`, because the default value of this header (`application/json`) gets wiped out in `ein:query-prepare-header`.

The above issue becomes more apparent when notebook contains non-ascii characters - in such case Jupyter logs a warning: `Invalid x-www-form-urlencoded body: 'latin-1' codec can't encode characters in position XXX: ordinal not in range(256)`.