### PR TITLE
Fix for bumping gc-cons-threshold while opening notebooks

### DIFF
--- a/lisp/ein-utils.el
+++ b/lisp/ein-utils.el
@@ -625,7 +625,6 @@ Use `ein:log' for debugging and logging."
 
 (lexical-let ((current-gc-cons-threshold gc-cons-threshold))
   (defun ein:gc-prepare-operation ()
-    (setq current-gc-cons-threshold gc-cons-threshold)
     (ein:log 'debug "[GC-PREPARE-OPERATION] Setting cons threshold to %s." (* current-gc-cons-threshold 10000) )
     (setq gc-cons-threshold (* current-gc-cons-threshold 10000)))
 

--- a/lisp/ein-worksheet.el
+++ b/lisp/ein-worksheet.el
@@ -203,6 +203,7 @@ this value."
       (setq buffer-undo-list t))
     (ein:worksheet-bind-events ws)
     (ein:worksheet-set-kernel ws)
+    (ein:gc-complete-operation)
     (ein:log 'info "Worksheet %s is ready" (ein:worksheet-full-name ws))))
 
 (defun ein:worksheet-pp (ewoc-data)


### PR DESCRIPTION
Make `ein:gc-prepare-operation` idempotent and add missing call to
`ein:gc-complete-operation` - without it, each subsequently opened notebook
bumps gc threshold to a higher and higher value, eventually disabling all
garbage collection and seriously degrading overall performance.