### PR TITLE
ein:console-executable-get: fail if console executable was not found

### DIFF
--- a/lisp/ein-console.el
+++ b/lisp/ein-console.el
@@ -151,7 +151,8 @@ See also: `ein:console-security-dir'."
     (file-name-as-directory (expand-file-name dir)))))
 
 (defun ein:console-executable-get (url-or-port)
-  (ein:choose-setting 'ein:console-executable url-or-port))
+  (or (ein:choose-setting 'ein:console-executable url-or-port)
+      (error "Cannot find console executable!")))
 
 (defun ein:console-args-get (url-or-port)
   (ein:choose-setting 'ein:console-args url-or-port
@@ -160,11 +161,14 @@ See also: `ein:console-security-dir'."
                             (and (listp x)
                                  (stringp (car x)))))))
 
+(defun ein:ensure-url-or-port ()
+  (or (ein:get-url-or-port)
+      (error "Cannot find notebook to connect!")))
+
 (defun ein:console-make-command ()
   ;; FIXME: use %connect_info to get connection file, then I can get
   ;; rid of `ein:console-security-dir'.
-  (let* ((url-or-port (or (ein:get-url-or-port)
-                          (error "Cannot find notebook to connect!")))
+  (let* ((url-or-port (ein:ensure-url-or-port))
          (dir (ein:console-security-dir-get url-or-port))
          (kid (ein:kernel-id (ein:get-kernel)))
          (ipy (ein:console-executable-get url-or-port))
@@ -199,8 +203,7 @@ It should be possible to support python-mode.el.  Patches are welcome!
   (interactive)
   ;; FIXME: Workaround for running current version of Jupyter console on windows
   (when (eql system-type 'windows-nt)
-    (if (string-match-p "jupyter" (ein:console-executable-get (or (ein:get-url-or-port)
-                                                                  (error "Cannot find notebook to connect!"))))
+    (if (string-match-p "jupyter" (ein:console-executable-get (ein:ensure-url-or-port)))
         (setenv "JUPYTER_CONSOLE_TEST" "1")
       (setenv "IPY_TEST_SIMPLE_PROMPT" "1")))
   (if (fboundp 'python-shell-switch-to-shell)


### PR DESCRIPTION
this is a minor change to fail just a little bit earlier and with a better message that `type-error`.