### PR TITLE
Asynchronize all server communication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ before_script:
   - cask install
 
 script:
-  - make test || cat log/*.server
+  - make test || ( for file in log/{testfunc,ecukes}.* ; do echo $file ;  cat $file ; done )

--- a/Cask
+++ b/Cask
@@ -3,7 +3,7 @@
 
 (package "ein" "0.14.2" "Emacs IPython Notebook.")
 (package-file "lisp/ein.el")
-(files "lisp/*.el" :exclude ("lisp/zeroein.el"))
+(files "lisp/*.el" (:exclude "lisp/zeroein.el"))
 
 (development
  (depends-on "websocket")

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,13 @@ IPY_VERSION = 5.8.0
 SRC=$(shell cask files)
 ELCFILES = $(SRC:.el=.elc)
 
+.PHONY: loaddefs
+loaddefs:
+	sh tools/update-autoloads.sh
+
 .PHONY: clean
 clean:
 	cask clean-elc
-	-rm -f log/testein*
-	-rm -f log/testfunc*
 
 env-ipy.%:
 	tools/makeenv.sh env/ipy.$* tools/requirement-ipy.$*.txt

--- a/features/notebooklist.feature
+++ b/features/notebooklist.feature
@@ -1,0 +1,35 @@
+Scenario: No warnings
+Given I switch to log expr "ein:log-all-buffer-name"
+Then I should see "[info]"
+And I should not see "[warn]"
+And I should not see "[error]"
+
+Scenario: Breadcrumbs
+  Given I am in notebooklist buffer
+  When I click on dir "step-definitions"
+  Then I should see "ein-steps"
+  And I click on "Home"
+  Then I should see "support"
+
+Scenario: New Notebook
+  Given I am in notebooklist buffer
+  When I clear log expr "ein:log-all-buffer-name"
+  And I click on "New Notebook"
+  And I switch to log expr "ein:log-all-buffer-name"
+  Then I should see "Opened notebook Untitled"
+
+Scenario: Resync
+  Given I am in notebooklist buffer
+  When I clear log expr "ein:log-all-buffer-name"
+  And I click on "Resync"
+  And I switch to log expr "ein:log-all-buffer-name"
+  Then I should see "kernelspecs--complete"
+
+@foo
+Scenario: Global notebooks
+  Given I am in notebooklist buffer
+  When I clear log expr "ein:log-all-buffer-name"
+  And I call "ein:notebooklist-open-notebook-global"
+  And I wait 0.9 seconds
+  And I switch to log expr "ein:log-all-buffer-name"
+  Then I should see "Opened notebook"

--- a/features/step-definitions/ein-steps.el
+++ b/features/step-definitions/ein-steps.el
@@ -1,3 +1,28 @@
+(When "^I clear log expr \"\\(.+\\)\"$"
+      (lambda (log-expr)
+        (with-current-buffer (symbol-value (intern log-expr))
+          (let ((inhibit-read-only t))
+            (erase-buffer)))))
+
+(When "^I switch to log expr \"\\(.+\\)\"$"
+      (lambda (log-expr)
+        (switch-to-buffer (symbol-value (intern log-expr)))))
+
+(When "^I am in notebooklist buffer$"
+      (lambda ()
+        (multiple-value-bind (url-or-port token) (ein:jupyter-server-conn-info)
+          (switch-to-buffer (ein:notebooklist-get-buffer url-or-port))
+          (sit-for 0.8)
+          )))
+
+(When "^I wait \\([.0-9]+\\) seconds$"
+      (lambda (seconds)
+        (sit-for (string-to-number seconds))))
+
+(When "^I am in log buffer$"
+      (lambda ()
+        (switch-to-buffer ein:log-all-buffer-name)))
+
 (When "^new \\(.+\\) notebook$"
       (lambda (kernel)
         (multiple-value-bind (url-or-port token) (ein:jupyter-server-conn-info)
@@ -13,6 +38,25 @@
                                     (ein:$notebook-notebook-name notebook))))
               (switch-to-buffer buf-name)
               (Then "I should be in buffer \"%s\"" buf-name))))))
+
+(When "^I click on \"\\(.+\\)\"$"
+      (lambda (word)
+        ;; from espuds "go to word" without the '\\b's
+        (goto-char (point-min))
+        (let ((search (re-search-forward (format "\\[%s\\]" word) nil t))
+              (message "Cannot go to link '%s' in buffer: %s"))
+          (cl-assert search nil message word (buffer-string))
+          (backward-char)
+          (When "I press \"RET\"")
+          (sit-for 0.8))))
+
+(When "^I click on dir \"\\(.+\\)\"$"
+      (lambda (dir)
+        (When (format "I go to word \"%s\"" dir))
+        (re-search-backward "Dir" nil t)
+        (When "I press \"RET\"")
+        (sit-for 0.8)
+))
 
 (When "^old notebook \"\\(.+\\)\"$"
       (lambda (path)

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -17,44 +17,13 @@
 (defvar ein:testing-jupyter-server-root (f-parent (f-dirname load-file-name)))
 (ein:deflocal ein:%testing-port% nil)
 
-(defun ein:testing-wait-until (predicate &optional predargs ms)
-  "Wait until PREDICATE function returns non-`nil'.
-  PREDARGS is argument list for the PREDICATE function.
-  MS is milliseconds to wait."
-  (let* ((subms 300)
-         (count (max 1 (if ms (truncate (/ ms subms)) 25))))
-    (unless (loop repeat count
-                  when (apply predicate predargs)
-                  return t
-                  do (sleep-for 0 subms))
-      (error "Timeout: %s" predicate))))
-
-(Setup
- (setq ein:force-sync t)
- (ein:dev-start-debug)
- (setq ein:notebook-autosave-frequency 10000)
- (setq ein:testing-dump-file-log "./log/ecukes.log")
- (setq ein:testing-dump-file-messages "./log/ecukes.messages")
- (setq ein:testing-dump-server-log  "./log/ecukes.server")
-
- (setq ein:jupyter-server-args '("--no-browser" "--debug"))
- (deferred:sync! (ein:jupyter-server-start (executable-find "jupyter") ein:testing-jupyter-server-root))
- (assert (processp %ein:jupyter-server-session%) t "notebook server defunct")
- (setq ein:%testing-url% (car (ein:jupyter-server-conn-info))
-))
-
-(After
+(defun ein:testing-after-scenario ()
  (with-current-buffer (ein:notebooklist-get-buffer ein:%testing-url%)
    (loop for buffer in (ein:notebook-opened-buffers)
          do (let ((kill-buffer-query-functions nil))
               (with-current-buffer buffer (not-modified))
               (kill-buffer buffer)))
-   (let ((sessions #s(hash-table test equal data (:pending t)))
-         (urlport (ein:$notebooklist-url-or-port ein:%notebooklist%)))
-     (ein:content-query-sessions sessions urlport)
-     (loop repeat 4
-           until (null (gethash :pending sessions))
-           do (sleep-for 0 50))
+   (let ((urlport (ein:$notebooklist-url-or-port ein:%notebooklist%)))
      (loop for note in (ein:$notebooklist-data ein:%notebooklist%)
            for path = (plist-get note :path)
            for notebook = (ein:notebook-get-opened-notebook urlport path)
@@ -62,14 +31,31 @@
              do (ein:notebook-kill-kernel-then-close-command notebook t)
                 (if (search "Untitled" path) 
                     (ein:notebooklist-delete-notebook path))
-           end))))
+           end)))
+)
+(Setup
+ (ein:dev-start-debug)
+ (setq ein:notebook-autosave-frequency 10000)
+ (setq ein:testing-dump-file-log (concat default-directory "log/ecukes.log"))
+ (setq ein:testing-dump-file-messages (concat default-directory "log/ecukes.messages"))
+ (setq ein:testing-dump-file-server  (concat default-directory  "log/ecukes.server"))
+ (setq ein:testing-dump-file-request  (concat default-directory "log/ecukes.request"))
+ (setq ein:jupyter-server-args '("--no-browser" "--debug"))
+ (setq ein:%testing-url% nil)
+ (deferred:sync! (ein:jupyter-server-start (executable-find "jupyter") ein:testing-jupyter-server-root))
+ (assert (processp %ein:jupyter-server-session%) t "notebook server defunct")
+ (setq ein:%testing-url% (car (ein:jupyter-server-conn-info))))
+
+(After
+ (ein:testing-after-scenario))
 
 (Teardown
  (cl-letf (((symbol-function 'y-or-n-p) (lambda (prompt) t)))
    (ein:jupyter-server-stop t))
- (ein:testing-dump-logs)
+; (ein:testing-dump-logs) ; taken care of by ein-testing.el kill-emacs-hook?
  (assert (not (processp %ein:jupyter-server-session%)) t "notebook server orphaned"))
 
 (Fail
- (if (not noninteractive)
-     (keyboard-quit))) ;; useful to prevent emacs from quitting
+ (if noninteractive
+     (ein:testing-after-scenario)
+   (keyboard-quit))) ;; useful to prevent emacs from quitting

--- a/features/undo.feature
+++ b/features/undo.feature
@@ -1,3 +1,4 @@
+@default
 Scenario: Undo by default turned off
   Given new default notebook
   When I type "import math"
@@ -5,6 +6,7 @@ Scenario: Undo by default turned off
   And I undo demoting errors
   Then I should see message "demoted: (user-error No undo information in this buffer)"
 
+@yank
 Scenario: Kill yank doesn't break undo
   Given I enable undo
   Given new default notebook

--- a/lisp/ein-cell.el
+++ b/lisp/ein-cell.el
@@ -258,9 +258,7 @@ a number will limit the number of lines in a cell output."
       (ein:oset-if-empty cell 'metadata (plist-get data :metadata))
       (ein:aif (plist-get (slot-value cell 'metadata) :slideshow)
           (let ((slide-type (nth 0 (cdr it))))
-            (setf (slot-value cell 'slidetype) slide-type)
-            (message "read slidetype %s" (slot-value cell 'slidetype))
-            (message "reconstructed slideshow %s" (ein:get-slide-show cell)))))
+            (setf (slot-value cell 'slidetype) slide-type))))
     cell))
 
 (defmethod ein:cell-init ((cell ein:codecell) data)

--- a/lisp/ein-connect.el
+++ b/lisp/ein-connect.el
@@ -180,7 +180,7 @@ notebooks."
      (ein:notebooklist-list-notebooks))))
   (ein:notebooklist-open-notebook-global
    nbpath
-   (lambda (notebook -ignore- buffer no-reconnection)
+   (lambda (notebook created buffer no-reconnection)
      (ein:connect-buffer-to-notebook notebook buffer no-reconnection))
    (list (or buffer (current-buffer)) no-reconnection)))
 
@@ -189,9 +189,10 @@ notebooks."
   "Connect any buffer to opened notebook and its kernel."
   (interactive (list (completing-read "Notebook buffer to connect: "
                                       (ein:notebook-opened-buffer-names))))
-  (let ((notebook
-         (buffer-local-value 'ein:%notebook% (get-buffer buffer-or-name))))
-    (ein:connect-buffer-to-notebook notebook)))
+  (ein:aif (get-buffer-buffer-or-name)
+      (let ((notebook (buffer-local-value 'ein:%notebook% it)))
+        (ein:connect-buffer-to-notebook notebook))
+    (error "No buffer %s" buffer-or-name)))
 
 ;;;###autoload
 (defun ein:connect-buffer-to-notebook (notebook &optional buffer

--- a/lisp/ein-dev.el
+++ b/lisp/ein-dev.el
@@ -119,6 +119,11 @@ When the prefix argument is given, debugging support for websocket
 callback (`websocket-callback-debug-on-error') is enabled."
   (interactive "P")
   (setq debug-on-error t)
+;; only use these with deferred:sync!  they cause strange failures otherwise!
+;;  (setq deferred:debug-on-signal t)
+;;  (setq deferred:debug t)
+  (setq request-log-level (quote debug))
+  (setq request-message-level (quote verbose))
   (setq websocket-debug t)
   (when ws-callback
     (setq websocket-callback-debug-on-error t))
@@ -130,10 +135,14 @@ callback (`websocket-callback-debug-on-error') is enabled."
 
 ;;;###autoload
 (defun ein:dev-stop-debug ()
-  "Disable debugging support enabled by `ein:dev-start-debug'."
+  "Inverse of `ein:dev-start-debug'.  Hard to maintain because it needs to match start"
   (interactive)
   (setq debug-on-error nil)
   (setq websocket-debug nil)
+  (setq deferred:debug-on-signal nil)
+  (setq deferred:debug nil)
+  (setq request-log-level -1)
+  (setq request-message-level 'warn)
   (setq websocket-callback-debug-on-error nil)
   (setq ein:debug nil)
   (ein:log-set-level 'verbose)

--- a/lisp/ein-file.el
+++ b/lisp/ein-file.el
@@ -35,8 +35,7 @@
           path))
 
 (defun ein:file-open (url-or-port path)
-  (ein:content-query-contents path url-or-port nil
-                              #'ein:file-open-finish))
+  (ein:content-query-contents url-or-port path #'ein:file-open-finish))
 
 (defun ein:file-open-finish (content)
   (with-current-buffer (get-buffer-create (ein:file-buffer-name (ein:$content-url-or-port content)

--- a/lisp/ein-jupyter.el
+++ b/lisp/ein-jupyter.el
@@ -174,11 +174,11 @@ the log of the running jupyter server."
   (setf *ein:last-jupyter-command* server-cmd-path
         *ein:last-jupyter-directory* notebook-directory)
   (if (buffer-live-p (get-buffer ein:jupyter-server-buffer-name))
-      (message "Notebook session is already running, check the contents of %s"
+      (ein:log 'info "Notebook session is already running, check the contents of %s"
                ein:jupyter-server-buffer-name))
   (add-hook 'kill-emacs-hook #'(lambda ()
                                  (ein:jupyter-server-stop t)))
-  (message "Starting notebook server in directory: %s" notebook-directory)
+  (ein:log 'info "Starting notebook server in directory: %s" notebook-directory)
   (lexical-let ((no-login-after-start-p no-login-after-start-p)
                 (no-popup no-popup)
                 (proc (ein:jupyter-server--run ein:jupyter-server-buffer-name
@@ -204,7 +204,6 @@ the log of the running jupyter server."
               (progn
                 (warn "[EIN] Jupyter server failed to start, cancelling operation.")
                 (ein:jupyter-server-stop t))
-            (ein:force-ipython-version-check)
             (unless no-login-p
               (ein:jupyter-server-login-and-open no-popup))))))))
 
@@ -245,8 +244,8 @@ there is no running server then no action will be taken.
       (let ((process (get-buffer-process (current-buffer))))
         (when process
           (let ((pid (process-id process)))
-            (ein:log 'info "Signaled %s with pid %s" process pid)
-            (message "Stopped Jupyter notebook server.")
+            (ein:log 'verbose "Signaled %s with pid %s" process pid)
+            (ein:log 'info "Stopped Jupyter notebook server.")
             (signal-process (process-id process) 15)))))
     (when log
       (with-current-buffer ein:jupyter-server-buffer-name

--- a/lisp/ein-loaddefs.el
+++ b/lisp/ein-loaddefs.el
@@ -3,62 +3,19 @@
 ;;; Code:
 
 
-;;;### (autoloads nil "ein-ac" "ein-ac.el" (0 0 0 0))
-;;; Generated autoloads from ein-ac.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-ac" '("ein:")))
-
-;;;***
-
-;;;### (autoloads nil "ein-cell" "ein-cell.el" (0 0 0 0))
-;;; Generated autoloads from ein-cell.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-cell" '("ein:")))
-
-;;;***
-
-;;;### (autoloads nil "ein-cell-edit" "ein-cell-edit.el" (0 0 0 0))
-;;; Generated autoloads from ein-cell-edit.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-cell-edit" '("ein:")))
-
-;;;***
-
-;;;### (autoloads nil "ein-cell-output" "ein-cell-output.el" (0 0
-;;;;;;  0 0))
-;;; Generated autoloads from ein-cell-output.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-cell-output" '("ein:")))
-
-;;;***
-
-;;;### (autoloads nil "ein-classes" "ein-classes.el" (0 0 0 0))
-;;; Generated autoloads from ein-classes.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-classes" '("ein:")))
-
-;;;***
-
-;;;### (autoloads nil "ein-company" "ein-company.el" (0 0 0 0))
+;;;### (autoloads nil "ein-company" "ein-company.el" (23475 34241
+;;;;;;  887134 78000))
 ;;; Generated autoloads from ein-company.el
 
 (autoload 'ein:company-backend "ein-company" "\
 
 
-\(fn COMMAND &optional ARG &rest IGNORE)" t nil)
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-company" '("ein:company-handle-doc-buffer")))
+\(fn COMMAND &optional ARG &rest _)" t nil)
 
 ;;;***
 
-;;;### (autoloads nil "ein-completer" "ein-completer.el" (0 0 0 0))
-;;; Generated autoloads from ein-completer.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-completer" '("ein:complete")))
-
-;;;***
-
-;;;### (autoloads nil "ein-connect" "ein-connect.el" (0 0 0 0))
+;;;### (autoloads nil "ein-connect" "ein-connect.el" (23468 61365
+;;;;;;  135112 242000))
 ;;; Generated autoloads from ein-connect.el
 
 (autoload 'ein:connect-to-notebook-command "ein-connect" "\
@@ -92,11 +49,10 @@ notebook.
 
 \(fn)" nil nil)
 
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-connect" '("ein:")))
-
 ;;;***
 
-;;;### (autoloads nil "ein-console" "ein-console.el" (0 0 0 0))
+;;;### (autoloads nil "ein-console" "ein-console.el" (23468 61365
+;;;;;;  135112 242000))
 ;;; Generated autoloads from ein-console.el
 
 (autoload 'ein:console-open "ein-console" "\
@@ -113,26 +69,10 @@ It should be possible to support python-mode.el.  Patches are welcome!
 
 \(fn)" t nil)
 
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-console" '("ein:console-")))
-
 ;;;***
 
-;;;### (autoloads nil "ein-contents-api" "ein-contents-api.el" (0
-;;;;;;  0 0 0))
-;;; Generated autoloads from ein-contents-api.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-contents-api" '("ein:" "update-content-path" "*ein:content-hierarchy*")))
-
-;;;***
-
-;;;### (autoloads nil "ein-core" "ein-core.el" (0 0 0 0))
-;;; Generated autoloads from ein-core.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-core" '("*running-ipython-version*" "ein:")))
-
-;;;***
-
-;;;### (autoloads nil "ein-dev" "ein-dev.el" (0 0 0 0))
+;;;### (autoloads nil "ein-dev" "ein-dev.el" (23477 31845 251244
+;;;;;;  240000))
 ;;; Generated autoloads from ein-dev.el
 
 (autoload 'ein:dev-insert-mode-map "ein-dev" "\
@@ -148,7 +88,7 @@ callback (`websocket-callback-debug-on-error') is enabled.
 \(fn &optional WS-CALLBACK)" t nil)
 
 (autoload 'ein:dev-stop-debug "ein-dev" "\
-Disable debugging support enabled by `ein:dev-start-debug'.
+Inverse of `ein:dev-start-debug'.  Hard to maintain.  Not really used.
 
 \(fn)" t nil)
 
@@ -157,25 +97,10 @@ Open a buffer with bug report template.
 
 \(fn)" t nil)
 
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-dev" '("ein:")))
-
 ;;;***
 
-;;;### (autoloads nil "ein-events" "ein-events.el" (0 0 0 0))
-;;; Generated autoloads from ein-events.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-events" '("ein:events-")))
-
-;;;***
-
-;;;### (autoloads nil "ein-file" "ein-file.el" (0 0 0 0))
-;;; Generated autoloads from ein-file.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-file" '("ein:" "*ein:file-buffername-template*")))
-
-;;;***
-
-;;;### (autoloads nil "ein-helm" "ein-helm.el" (0 0 0 0))
+;;;### (autoloads nil "ein-helm" "ein-helm.el" (23064 59027 190301
+;;;;;;  971000))
 ;;; Generated autoloads from ein-helm.el
 
 (autoload 'anything-ein-kernel-history "ein-helm" "\
@@ -198,18 +123,10 @@ Choose opened notebook using helm interface.
 
 \(fn)" t nil)
 
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-helm" '("ein:helm-")))
-
 ;;;***
 
-;;;### (autoloads nil "ein-hy" "ein-hy.el" (0 0 0 0))
-;;; Generated autoloads from ein-hy.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-hy" '("ein:cell-")))
-
-;;;***
-
-;;;### (autoloads nil "ein-iexec" "ein-iexec.el" (0 0 0 0))
+;;;### (autoloads nil "ein-iexec" "ein-iexec.el" (23064 59027 190301
+;;;;;;  971000))
 ;;; Generated autoloads from ein-iexec.el
 
 (autoload 'ein:iexec-mode "ein-iexec" "\
@@ -219,11 +136,10 @@ change in its input area.
 
 \(fn &optional ARG)" t nil)
 
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-iexec" '("ein:iexec-")))
-
 ;;;***
 
-;;;### (autoloads nil "ein-inspector" "ein-inspector.el" (0 0 0 0))
+;;;### (autoloads nil "ein-inspector" "ein-inspector.el" (23475 34241
+;;;;;;  887134 78000))
 ;;; Generated autoloads from ein-inspector.el
 
 (autoload 'ein:inspect-object "ein-inspector" "\
@@ -231,19 +147,10 @@ change in its input area.
 
 \(fn KERNEL OBJECT)" t nil)
 
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-inspector" '("ein:")))
-
 ;;;***
 
-;;;### (autoloads nil "ein-ipdb" "ein-ipdb.el" (0 0 0 0))
-;;; Generated autoloads from ein-ipdb.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-ipdb" '("ein:" "*ein:ipdb-")))
-
-;;;***
-
-;;;### (autoloads nil "ein-ipynb-mode" "ein-ipynb-mode.el" (0 0 0
-;;;;;;  0))
+;;;### (autoloads nil "ein-ipynb-mode" "ein-ipynb-mode.el" (23064
+;;;;;;  59027 194301 980000))
 ;;; Generated autoloads from ein-ipynb-mode.el
 
 (autoload 'ein:ipynb-mode "ein-ipynb-mode" "\
@@ -253,11 +160,10 @@ A simple mode for ipynb file.
 
 (add-to-list 'auto-mode-alist '(".*\\.ipynb\\'" . ein:ipynb-mode))
 
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-ipynb-mode" '("ein:ipynb-parent-mode")))
-
 ;;;***
 
-;;;### (autoloads nil "ein-jedi" "ein-jedi.el" (0 0 0 0))
+;;;### (autoloads nil "ein-jedi" "ein-jedi.el" (23468 61365 139112
+;;;;;;  317000))
 ;;; Generated autoloads from ein-jedi.el
 
 (autoload 'ein:jedi-complete "ein-jedi" "\
@@ -282,33 +188,10 @@ To use EIN and Jedi together, add the following in your Emacs setup before loadi
 
 \(fn)" nil nil)
 
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-jedi" '("ein:jedi-")))
-
 ;;;***
 
-;;;### (autoloads nil "ein-junk" "ein-junk.el" (0 0 0 0))
-;;; Generated autoloads from ein-junk.el
-
-(autoload 'ein:junk-new "ein-junk" "\
-Open a notebook to try random thing.
-Notebook name is determined based on
-`ein:junk-notebook-name-template'.
-
-When prefix argument is given, it asks URL or port to use.
-
-\(fn NAME KERNELSPEC URL-OR-PORT)" t nil)
-
-(autoload 'ein:junk-rename "ein-junk" "\
-Rename the current notebook based on `ein:junk-notebook-name-template'
-and save it immediately.
-
-\(fn NAME)" t nil)
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-junk" '("ein:junk-notebook-name")))
-
-;;;***
-
-;;;### (autoloads nil "ein-jupyter" "ein-jupyter.el" (0 0 0 0))
+;;;### (autoloads nil "ein-jupyter" "ein-jupyter.el" (23478 35725
+;;;;;;  832413 900000))
 ;;; Generated autoloads from ein-jupyter.el
 
 (autoload 'ein:jupyter-server-login-and-open "ein-jupyter" "\
@@ -349,14 +232,12 @@ Stop a running jupyter notebook server.
 Use this command to stop a running jupyter notebook server. If
 there is no running server then no action will be taken.
 
-\(fn &optional FORCE)" t nil)
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-jupyter" '("%ein:jupyter-server-session%" "*ein:" "ein:jupyter-")))
+\(fn &optional FORCE LOG)" t nil)
 
 ;;;***
 
-;;;### (autoloads nil "ein-jupyterhub" "ein-jupyterhub.el" (0 0 0
-;;;;;;  0))
+;;;### (autoloads nil "ein-jupyterhub" "ein-jupyterhub.el" (23468
+;;;;;;  61365 139112 317000))
 ;;; Generated autoloads from ein-jupyterhub.el
 
 (autoload 'ein:jupyterhub-connect "ein-jupyterhub" "\
@@ -364,44 +245,20 @@ Log on to a jupyterhub server using PAM authentication. Requires jupyterhub vers
 
 \(fn URL USER PASSWORD)" t nil)
 
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-jupyterhub" '("ein:j")))
-
 ;;;***
 
-;;;### (autoloads nil "ein-kernel" "ein-kernel.el" (0 0 0 0))
+;;;### (autoloads nil "ein-kernel" "ein-kernel.el" (23475 34241 891134
+;;;;;;  103000))
 ;;; Generated autoloads from ein-kernel.el
 
 (defalias 'ein:kernel-url-or-port 'ein:$kernel-url-or-port)
 
 (defalias 'ein:kernel-id 'ein:$kernel-kernel-id)
 
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-kernel" '("ein:" "kernel-restart-try-count" "max-kernel-restart-try-count")))
-
 ;;;***
 
-;;;### (autoloads nil "ein-kernelinfo" "ein-kernelinfo.el" (0 0 0
-;;;;;;  0))
-;;; Generated autoloads from ein-kernelinfo.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-kernelinfo" '("ein:kernelinfo")))
-
-;;;***
-
-;;;### (autoloads nil "ein-kill-ring" "ein-kill-ring.el" (0 0 0 0))
-;;; Generated autoloads from ein-kill-ring.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-kill-ring" '("ein:")))
-
-;;;***
-
-;;;### (autoloads nil "ein-log" "ein-log.el" (0 0 0 0))
-;;; Generated autoloads from ein-log.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-log" '("ein:")))
-
-;;;***
-
-;;;### (autoloads nil "ein-multilang" "ein-multilang.el" (0 0 0 0))
+;;;### (autoloads nil "ein-multilang" "ein-multilang.el" (23468 61365
+;;;;;;  139112 317000))
 ;;; Generated autoloads from ein-multilang.el
 
 (autoload 'ein:notebook-multilang-mode "ein-multilang" "\
@@ -409,47 +266,39 @@ Notebook mode with multiple language fontification.
 
 \(fn)" t nil)
 
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-multilang" '("ein:" "python-imenu-format-parent-item-jump-label")))
-
 ;;;***
 
-;;;### (autoloads nil "ein-multilang-fontify" "ein-multilang-fontify.el"
-;;;;;;  (0 0 0 0))
-;;; Generated autoloads from ein-multilang-fontify.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-multilang-fontify" '("ein:mlf-")))
-
-;;;***
-
-;;;### (autoloads nil "ein-node" "ein-node.el" (0 0 0 0))
-;;; Generated autoloads from ein-node.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-node" '("ein:")))
-
-;;;***
-
-;;;### (autoloads nil "ein-notebook" "ein-notebook.el" (0 0 0 0))
+;;;### (autoloads nil "ein-notebook" "ein-notebook.el" (23478 25882
+;;;;;;  960574 643000))
 ;;; Generated autoloads from ein-notebook.el
+
+(autoload 'ein:junk-new "ein-notebook" "\
+Open a notebook to try random thing.
+Notebook name is determined based on
+`ein:junk-notebook-name-template'.
+
+When prefix argument is given, it asks URL or port to use.
+
+\(fn NAME KERNELSPEC URL-OR-PORT)" t nil)
+
+(autoload 'ein:junk-rename "ein-notebook" "\
+Rename the current notebook based on `ein:junk-notebook-name-template'
+and save it immediately.
+
+\(fn NAME)" t nil)
 
 (defalias 'ein:notebook-name 'ein:$notebook-notebook-name)
 
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-notebook" '("ein:")))
-
 ;;;***
 
-;;;### (autoloads nil "ein-notebooklist" "ein-notebooklist.el" (0
-;;;;;;  0 0 0))
+;;;### (autoloads nil "ein-notebooklist" "ein-notebooklist.el" (23478
+;;;;;;  30232 414267 512000))
 ;;; Generated autoloads from ein-notebooklist.el
 
 (autoload 'ein:notebooklist-open "ein-notebooklist" "\
 Open notebook list buffer.
 
-\(fn &optional URL-OR-PORT PATH NO-POPUP)" t nil)
-
-(autoload 'ein:notebooklist-refresh-kernelspecs "ein-notebooklist" "\
-
-
-\(fn &optional URL-OR-PORT)" t nil)
+\(fn URL-OR-PORT &optional PATH NO-POPUP RESYNC)" t nil)
 
 (autoload 'ein:notebooklist-enable-keepalive "ein-notebooklist" "\
 Enable periodic calls to the notebook server to keep long running sessions from expiring.
@@ -470,7 +319,7 @@ Disable the notebooklist keepalive calls to the jupyter notebook server.
 (autoload 'ein:notebooklist-reload "ein-notebooklist" "\
 Reload current Notebook list.
 
-\(fn &optional NOTEBOOKLIST)" t nil)
+\(fn NOTEBOOKLIST &optional RESYNC)" t nil)
 
 (autoload 'ein:notebooklist-upload-file "ein-notebooklist" "\
 
@@ -537,19 +386,10 @@ on all the notebooks opened from the current notebooklist.
 
 \(fn NEW-URL-OR-PORT)" t nil)
 
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-notebooklist" '("ein:" "generate-breadcrumbs" "render-")))
-
 ;;;***
 
-;;;### (autoloads nil "ein-notification" "ein-notification.el" (0
-;;;;;;  0 0 0))
-;;; Generated autoloads from ein-notification.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-notification" '("ein:")))
-
-;;;***
-
-;;;### (autoloads nil "ein-org" "ein-org.el" (0 0 0 0))
+;;;### (autoloads nil "ein-org" "ein-org.el" (23468 61365 139112
+;;;;;;  317000))
 ;;; Generated autoloads from ein-org.el
 
 (autoload 'ein:org-open "ein-org" "\
@@ -582,27 +422,10 @@ node `(org) External links' and Info node `(org) Search options'
 
 (eval-after-load "org" '(if (fboundp 'org-link-set-parameters) (org-link-set-parameters "ipynb" :follow 'ein:org-open :help-echo "Open ipython notebook." :store 'ein:org-store-link) (org-add-link-type "ipynb" :follow 'ein:org-open) (add-hook 'org-store-link-functions 'ein:org-store-link)))
 
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-org" '(#("ein:org-goto-link" 0 17 (fontified nil)))))
-
-;;;***
-
-;;;### (autoloads nil "ein-output-area" "ein-output-area.el" (0 0
-;;;;;;  0 0))
-;;; Generated autoloads from ein-output-area.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-output-area" '("ein:")))
-
-;;;***
-
-;;;### (autoloads nil "ein-pager" "ein-pager.el" (0 0 0 0))
-;;; Generated autoloads from ein-pager.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-pager" '("ein:pager-")))
-
 ;;;***
 
 ;;;### (autoloads nil "ein-pseudo-console" "ein-pseudo-console.el"
-;;;;;;  (0 0 0 0))
+;;;;;;  (23064 59027 198301 987000))
 ;;; Generated autoloads from ein-pseudo-console.el
 
 (autoload 'ein:pseudo-console-mode "ein-pseudo-console" "\
@@ -610,41 +433,10 @@ Pseudo console mode.  Hit RET to execute code.
 
 \(fn &optional ARG)" t nil)
 
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-pseudo-console" '("ein:pseudo-console-mode-map")))
-
-;;;***
-
-;;;### (autoloads nil "ein-python" "ein-python.el" (0 0 0 0))
-;;; Generated autoloads from ein-python.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-python" '("ein:python-")))
-
-;;;***
-
-;;;### (autoloads nil "ein-pytools" "ein-pytools.el" (0 0 0 0))
-;;; Generated autoloads from ein-pytools.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-pytools" '("ein:")))
-
-;;;***
-
-;;;### (autoloads nil "ein-query" "ein-query.el" (0 0 0 0))
-;;; Generated autoloads from ein-query.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-query" '(#("ein:" 0 4 (face font-lock-function-name-face fontified nil)) #("*ein:jupyterhub-servers*" 0 24 (fontified nil face font-lock-variable-name-face)))))
-
-;;;***
-
-;;;### (autoloads nil "ein-scratchsheet" "ein-scratchsheet.el" (0
-;;;;;;  0 0 0))
-;;; Generated autoloads from ein-scratchsheet.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-scratchsheet" '("ein:")))
-
 ;;;***
 
 ;;;### (autoloads nil "ein-shared-output" "ein-shared-output.el"
-;;;;;;  (0 0 0 0))
+;;;;;;  (23468 61365 139112 317000))
 ;;; Generated autoloads from ein-shared-output.el
 
 (autoload 'ein:shared-output-pop-to-buffer "ein-shared-output" "\
@@ -671,40 +463,10 @@ shared output buffer.  You can open the buffer by the command
 
 \(fn CODE &optional POPUP VERBOSE KERNEL &rest ARGS)" t nil)
 
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-shared-output" '("ein:")))
-
 ;;;***
 
-;;;### (autoloads nil "ein-skewer" "ein-skewer.el" (0 0 0 0))
-;;; Generated autoloads from ein-skewer.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-skewer" '("ein:" "*ein:skewer-running-p*")))
-
-;;;***
-
-;;;### (autoloads nil "ein-smartrep" "ein-smartrep.el" (0 0 0 0))
-;;; Generated autoloads from ein-smartrep.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-smartrep" '("ein:smartrep-")))
-
-;;;***
-
-;;;### (autoloads nil "ein-subpackages" "ein-subpackages.el" (0 0
-;;;;;;  0 0))
-;;; Generated autoloads from ein-subpackages.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-subpackages" '(#("ein:" 0 4 (face font-lock-function-name-face fontified t)))))
-
-;;;***
-
-;;;### (autoloads nil "ein-timestamp" "ein-timestamp.el" (0 0 0 0))
-;;; Generated autoloads from ein-timestamp.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-timestamp" '("ein:")))
-
-;;;***
-
-;;;### (autoloads nil "ein-traceback" "ein-traceback.el" (0 0 0 0))
+;;;### (autoloads nil "ein-traceback" "ein-traceback.el" (23468 61365
+;;;;;;  139112 317000))
 ;;; Generated autoloads from ein-traceback.el
 
 (autoload 'ein:tb-show "ein-traceback" "\
@@ -712,47 +474,19 @@ Show full traceback in traceback viewer.
 
 \(fn)" t nil)
 
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-traceback" '("ein:t")))
-
 ;;;***
 
-;;;### (autoloads nil "ein-utils" "ein-utils.el" (0 0 0 0))
-;;; Generated autoloads from ein-utils.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-utils" '("ein:")))
-
-;;;***
-
-;;;### (autoloads nil "ein-websocket" "ein-websocket.el" (0 0 0 0))
-;;; Generated autoloads from ein-websocket.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-websocket" '("ein:websocket" "fix-request-netscape-cookie-parse")))
-
-;;;***
-
-;;;### (autoloads nil "ein-worksheet" "ein-worksheet.el" (0 0 0 0))
-;;; Generated autoloads from ein-worksheet.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ein-worksheet" '("ein:")))
-
-;;;***
-
-;;;### (autoloads nil "ob-ein" "ob-ein.el" (0 0 0 0))
-;;; Generated autoloads from ob-ein.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "ob-ein" '("*ein:org-name-generator*" "ein:" "org-babel-")))
-
-;;;***
-
-;;;### (autoloads nil "zeroein" "zeroein.el" (0 0 0 0))
-;;; Generated autoloads from zeroein.el
-
-(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "zeroein" '("zeroein:")))
-
-;;;***
-
-;;;### (autoloads nil nil ("debug-ein.el" "ein-pkg.el" "ein.el")
-;;;;;;  (0 0 0 0))
+;;;### (autoloads nil nil ("debug-ein.el" "ein-ac.el" "ein-cell-edit.el"
+;;;;;;  "ein-cell-output.el" "ein-cell.el" "ein-classes.el" "ein-completer.el"
+;;;;;;  "ein-contents-api.el" "ein-core.el" "ein-events.el" "ein-file.el"
+;;;;;;  "ein-hy.el" "ein-ipdb.el" "ein-junk.el" "ein-kernelinfo.el"
+;;;;;;  "ein-kill-ring.el" "ein-log.el" "ein-multilang-fontify.el"
+;;;;;;  "ein-node.el" "ein-notification.el" "ein-output-area.el"
+;;;;;;  "ein-pager.el" "ein-pkg.el" "ein-python.el" "ein-pytools.el"
+;;;;;;  "ein-query.el" "ein-scratchsheet.el" "ein-skewer.el" "ein-smartrep.el"
+;;;;;;  "ein-subpackages.el" "ein-timestamp.el" "ein-utils.el" "ein-websocket.el"
+;;;;;;  "ein-worksheet.el" "ein.el" "ob-ein.el" "zeroein.el") (23475
+;;;;;;  34241 891134 103000))
 
 ;;;***
 

--- a/lisp/ein-log.el
+++ b/lisp/ein-log.el
@@ -70,7 +70,7 @@
     (let* ((levname (ein:log-level-int-to-name level))
            (print-level ein:log-print-level)
            (print-length ein:log-print-length)
-           (msg (format "[%s] %s"  levname (funcall func)))
+           (msg (format "%s: [%s] %s" (format-time-string "%H:%M:%S:%3N") levname (funcall func)))
            (orig-buffer (current-buffer)))
       (if (and ein:log-max-string
                (> (length msg) ein:log-max-string))

--- a/lisp/ein-query.el
+++ b/lisp/ein-query.el
@@ -158,7 +158,9 @@ KEY, then call `request' with URL and SETTINGS.  KEY is compared by
       (setq settings (plist-put settings :timeout (/ timeout 1000.0))))
     (ein:aif (gethash key ein:query-running-process-table)
         (unless (request-response-done-p it)
-          (request-abort it)))            ; This will run callbacks
+          ;; This seems to result in clobbered cookie jars
+          ;;(request-abort it) ; This will run callbacks
+          (ein:log 'info "Race! %s %s" key (request-response-data it))))
     (let ((response (apply #'request (url-encode-url (ein:jupyterhub-correct-query-url-maybe url))
                            (ein:query-prepare-header url settings))))
       (puthash key response ein:query-running-process-table)

--- a/lisp/ob-ein.el
+++ b/lisp/ob-ein.el
@@ -298,10 +298,13 @@ given in the session parameter."
   (when (and (stringp session) (string= session "none"))
     (error "You must specify a notebook or kernelspec as the session variable for ein code blocks."))
   (multiple-value-bind (url-or-port path) (ein:org-babel-parse-session session)
-    (if (null (gethash url-or-port ein:available-kernelspecs))
-        (ein:query-kernelspecs url-or-port))
-    (if (null kernelspec)
-        (setq kernelspec (ein:get-kernelspec url-or-port "default")))
+    (when (null kernelspec)
+      ;; Now is not the time to be getting kernelspecs.
+      ;; If I must do so, need to inject a deferred callback chain like
+      ;; in ein:notebooklist
+      ;; (if (null (gethash url-or-port ein:available-kernelspecs))
+      ;;     (ein:query-kernelspecs url-or-port))
+      (setq kernelspec (ein:get-kernelspec url-or-port "default")))
     (cond ((null path)
            (let* ((name ein:org-babel-default-session-name)
                   (new-session (format "%s/%s" url-or-port name)))

--- a/test/ein-testing-notebook.el
+++ b/test/ein-testing-notebook.el
@@ -45,17 +45,17 @@
     ;; "bindings are lexical... all references to the named functions
     ;; must appear physically within the body of the cl-flet"
     (flet ((pop-to-buffer (buf) buf)
-           (ein:query-ipython-version (&optional url-or-port force) 3)
+           (ein:need-ipython-version (url-or-port) 3)
            (ein:notebook-start-kernel (notebook))
            (ein:notebook-enable-autosaves (notebook)))
       (let ((notebook (ein:notebook-new ein:testing-notebook-dummy-url path kernelspec)))
         (setf (ein:$notebook-kernel notebook)
-              (ein:kernel-new 8888 "/kernels" (ein:$notebook-events notebook) (ein:query-ipython-version)))
+              (ein:kernel-new 8888 "/kernels" (ein:$notebook-events notebook) (ein:need-ipython-version (ein:$notebook-url-or-port notebook))))
         (setf (ein:$kernel-events (ein:$notebook-kernel notebook))
               (ein:events-new))
         ; matryoshka: new-content makes a ein:$content using CONTENT as template 
         ; populating its raw_content field with DATA's content field
-        (ein:notebook-request-open-callback notebook (ein:new-content content nil :data data))
+        (ein:notebook-request-open-callback notebook (ein:new-content (ein:$notebook-url-or-port notebook) (ein:$notebook-notebook-path notebook) data))
         (ein:notebook-buffer notebook)))))
 
 (defun ein:testing-notebook-make-data (name path cells)

--- a/test/ein-testing.el
+++ b/test/ein-testing.el
@@ -26,6 +26,7 @@
 ;;; Code:
 
 (require 'ein-log)
+(require 'request)
 
 (defmacro ein:setq-if-not (sym val)
   `(unless ,sym (setq ,sym ,val)))
@@ -36,9 +37,11 @@
 (defvar ein:testing-dump-file-messages nil
   "File to save the ``*Messages*`` buffer.")
 
-(defvar ein:testing-dump-file-debug nil)
+(defvar ein:testing-dump-file-server nil
+  "File to save `ein:jupyter-server-buffer-name`.")
 
-(defvar ein:testing-dump-server-log nil)
+(defvar ein:testing-dump-file-request nil
+  "File to save `request-log-buffer-name`.")
 
 (defun ein:testing-save-buffer (buffer-or-name file-name)
   (when (and buffer-or-name (get-buffer buffer-or-name) file-name)
@@ -47,29 +50,28 @@
 
 (defun ein:testing-dump-logs ()
   (ein:testing-save-buffer "*Messages*" ein:testing-dump-file-messages)
-  (ein:testing-save-buffer "*ein:jupyter-server*" ein:testing-dump-server-log)
-  (ein:testing-save-buffer ein:log-all-buffer-name ein:testing-dump-file-log))
+  (ein:testing-save-buffer "*ein:jupyter-server*" ein:testing-dump-file-server)
+  (ein:testing-save-buffer ein:log-all-buffer-name ein:testing-dump-file-log)
+  (ein:testing-save-buffer request-log-buffer-name ein:testing-dump-file-request))
 
-(defvar ein:testing-dump-logs--saved nil)
-
-(defun ein:testing-dump-logs-noerror ()
-  (if ein:testing-dump-logs--saved
-      (message "EIN:TESTING-DUMP-LOGS-NOERROR called but already saved.")
-    (condition-case err
-        (progn (ein:testing-dump-logs)
-               (setq ein:testing-dump-logs--saved t))
-      (error
-       (message "Error while executing EIN:TESTING-DUMP-LOGS. err = %S"
-                err)
-       (when ein:testing-dump-file-debug
-         (signal (car err) (cdr err)))))))
+(defun ein:testing-wait-until (predicate &optional predargs ms interval)
+  "Wait until PREDICATE function returns non-`nil'.
+  PREDARGS is argument list for the PREDICATE function.
+  MS is milliseconds to wait.  INTERVAL is polling interval in milliseconds."
+  (let* ((interval (or interval 300))
+         (count (max 1 (if ms (truncate (/ ms interval)) 25))))
+    (unless (loop repeat count
+                  when (apply predicate predargs)
+                  return t
+                  do (sleep-for 0 interval))
+      (error "Timeout: %s" predicate))))
 
 (defadvice ert-run-tests-batch (after ein:testing-dump-logs-hook activate)
-  "Hook `ein:testing-dump-logs-noerror' because `kill-emacs-hook'
+  "Hook `ein:testing-dump-logs-hook' because `kill-emacs-hook'
 is not run in batch mode before Emacs 24.1."
-  (ein:testing-dump-logs-noerror))
+  (ein:testing-dump-logs))
 
-(add-hook 'kill-emacs-hook #'ein:testing-dump-logs-noerror)
+(add-hook 'kill-emacs-hook #'ein:testing-dump-logs)
 
 (provide 'ein-testing)
 

--- a/test/test-ein-notebooklist.el
+++ b/test/test-ein-notebooklist.el
@@ -3,9 +3,9 @@
 
 (defun eintest:notebooklist-make-empty (&optional url-or-port)
   "Make empty notebook list buffer."
-  (flet ((ein:query-kernelspecs (url-or-port &optional force-refresh))
-         (ein:content-query-sessions (session-hash url-or-port &optional force-sync)))
-    (ein:notebooklist-url-retrieve-callback 
+  (flet ((ein:need-kernelspecs (url-or-port))
+         (ein:content-query-sessions (session-hash url-or-port)))
+    (ein:notebooklist-open--finish
      (make-ein:$content :url-or-port (or url-or-port ein:testing-notebook-dummy-url)
                         :ipython-version 3
                         :path ""))))

--- a/test/test-func.el
+++ b/test/test-func.el
@@ -16,29 +16,12 @@
 
 (setq message-log-max t)
 
-(defun ein:testing-wait-until (message predicate &optional predargs max-count)
-  "Wait until PREDICATE function returns non-`nil'.
-PREDARGS is argument list for the PREDICATE function.
-Make MAX-COUNT larger \(default 50) to wait longer before timeout."
-  (ein:log 'debug "TESTING-WAIT-UNTIL start")
-  (ein:log 'debug "TESTING-WAIT-UNTIL waiting on: %s" message)
-  (unless max-count (setq max-count 50))
-  (unless (loop repeat max-count
-                when (apply predicate predargs)
-                return t
-                ;; borrowed from `deferred:sync!':
-                do (sit-for 0.2)
-                do (sleep-for 0.2))
-    (error "Timeout"))
-  (ein:log 'debug "TESTING-WAIT-UNTIL end"))
-
 (defun ein:testing-get-notebook-by-name (url-or-port notebook-name &optional path)
   (ein:log 'debug "TESTING-GET-NOTEBOOK-BY-NAME start")
   (when path
     (setq notebook-name (format "%s/%s" path notebook-name)))
   (ein:notebooklist-open url-or-port path t)
-  (ein:testing-wait-until "ein:notebooklist-open"
-                          (lambda () (and (bufferp (get-buffer (format ein:notebooklist-buffer-name-template url-or-port)))
+  (ein:testing-wait-until (lambda () (and (bufferp (get-buffer (format ein:notebooklist-buffer-name-template url-or-port)))
                                           (ein:notebooklist-get-buffer url-or-port))))
   (with-current-buffer (ein:notebooklist-get-buffer url-or-port)
     (prog1
@@ -60,31 +43,25 @@ Make MAX-COUNT larger \(default 50) to wait longer before timeout."
         (ein:notebooklist-new-notebook url-or-port kernelspec path
                                        (lambda (&rest -ignore-)
                                          (setq created t)))
-        (ein:testing-wait-until "ein:notebooklist-new-notebook"
-                                (lambda () created)))
+        (ein:testing-wait-until (lambda () created)))
       (prog1
           (ein:testing-get-notebook-by-name url-or-port "Untitled.ipynb" path)
         (ein:log 'debug "TESTING-GET-UNTITLED0-OR-CREATE end")))))
 
 (defvar ein:notebooklist-after-open-hook nil)
 
-(defadvice ein:notebooklist-url-retrieve-callback
-  (after ein:testing-notebooklist-url-retrieve-callback activate)
+(defadvice ein:notebooklist-open--finish
+  (after ein:testing-notebooklist-open--finish activate)
   "Advice to add `ein:notebooklist-after-open-hook'."
   (run-hooks 'ein:notebooklist-after-open-hook))
 
 (defun ein:testing-delete-notebook (url-or-port notebook &optional path)
   (ein:log 'debug "TESTING-DELETE-NOTEBOOK start")
   (ein:notebooklist-open url-or-port (ein:$notebook-notebook-path notebook) t)
-  (ein:testing-wait-until "ein:notebooklist-open"
-                          (lambda ()
-                            (bufferp (get-buffer (format ein:notebooklist-buffer-name-template url-or-port))))
-                          nil 50)
+  (ein:testing-wait-until (lambda ()
+                            (bufferp (get-buffer (format ein:notebooklist-buffer-name-template url-or-port)))))
   (with-current-buffer (ein:notebooklist-get-buffer url-or-port)
-    (ein:testing-wait-until "ein:notebooklist-get-buffer"
-                            (lambda () (eql major-mode 'ein:notebooklist-mode))
-                            nil
-                            50)
+    (ein:testing-wait-until (lambda () (eql major-mode 'ein:notebooklist-mode)))
     (ein:log 'debug "TESTING-DELETE-NOTEBOOK deleting notebook")
     (ein:notebooklist-delete-notebook (ein:$notebook-notebook-path notebook)))
   (ein:log 'debug "TESTING-DELETE-NOTEBOOK end"))
@@ -103,29 +80,24 @@ Make MAX-COUNT larger \(default 50) to wait longer before timeout."
   (ein:log 'verbose "ERT OPEN-NOTEBOOKLIST start")
   (ein:notebooklist-open *ein:testing-port* "/" t)
   (ein:testing-wait-until
-   "ein:notebooklist-open"
    (lambda ()
-     (ein:notebooklist-get-buffer *ein:testing-port*))
-   nil 5000)
+     (ein:notebooklist-get-buffer *ein:testing-port*)))
   (with-current-buffer (ein:notebooklist-get-buffer *ein:testing-port*)
     (should (eql major-mode 'ein:notebooklist-mode))))
 
 
 (ert-deftest 00-query-kernelspecs ()
   (ein:log 'info "ERT QUERY-KERNELSPECS")
-  (ein:log 'info (format "ERT QUERY-KERNELSPECS: Pre-query kernelspec count %s." (hash-table-count ein:available-kernelspecs)))
-  (ein:query-kernelspecs *ein:testing-port*)
-  (should (>= (hash-table-count ein:available-kernelspecs) 1))
-  (ein:log 'info (format "ERT QUERY-KERNELSPECS: Post-query kernelspec %S." (ein:list-available-kernels *ein:testing-port*))))
+  (ein:log 'info (format "ERT QUERY-KERNELSPECS: Pre-query kernelspec count %s." (hash-table-count *ein:kernelspecs*)))
+  (should (>= (hash-table-count *ein:kernelspecs*) 1))
+  (ein:log 'info (format "ERT QUERY-KERNELSPECS: Post-query kernelspec %S." (ein:need-kernelspecs *ein:testing-port*))))
 
 (ert-deftest 10-get-untitled0-or-create ()
   (ein:log 'verbose "ERT TESTING-GET-UNTITLED0-OR-CREATE start")
   (let ((notebook (ein:testing-get-untitled0-or-create *ein:testing-port*)))
     (ein:testing-wait-until
-     "ein:testing-get-untitled0-or-create"
      (lambda () (ein:aand (ein:$notebook-kernel notebook)
-                          (ein:kernel-live-p it)))
-     nil)
+                          (ein:kernel-live-p it))))
     (with-current-buffer (ein:notebook-buffer notebook)
       (should (equal (ein:$notebook-notebook-name ein:%notebook%)
                      "Untitled.ipynb"))))
@@ -137,12 +109,10 @@ Make MAX-COUNT larger \(default 50) to wait longer before timeout."
   (ein:log 'verbose "ERT TESTING-DELETE-UNTITLED0 creating notebook")
   (let ((notebook (ein:testing-get-untitled0-or-create *ein:testing-port*)))
     (ein:testing-wait-until
-     "ein:test-get-untitled0-or-create"
      (lambda ()
        (ein:aand notebook
                  (ein:$notebook-kernel it)
-                 (ein:kernel-live-p it)))
-     nil 50)
+                 (ein:kernel-live-p it))))
     (ein:log 'verbose "ERT TESTING-DELETE-UNTITLED0 deleting notebook")
     (ein:testing-delete-notebook *ein:testing-port* notebook))
   (ein:log 'verbose
@@ -157,17 +127,13 @@ Make MAX-COUNT larger \(default 50) to wait longer before timeout."
 (ert-deftest 11-notebook-execute-current-cell-simple ()
   (let ((notebook (ein:testing-get-untitled0-or-create *ein:testing-port*)))
     (ein:testing-wait-until
-     "ein:testing-get-untitled0-or-create"
      (lambda () (ein:aand (ein:$notebook-kernel notebook)
-                          (ein:kernel-live-p it)))
-     nil 50)
+                          (ein:kernel-live-p it))))
     (with-current-buffer (ein:notebook-buffer notebook)
       (call-interactively #'ein:worksheet-insert-cell-below)
       (insert "a = 100\na")
       (let ((cell (call-interactively #'ein:worksheet-execute-cell)))
-        (ein:testing-wait-until "ein:worksheet-execute-cell"
-                                (lambda () (not (slot-value cell 'running)))
-                                nil))
+        (ein:testing-wait-until (lambda () (not (slot-value cell 'running)))))
       ;; (message "%s" (buffer-string))
       (save-excursion
         (should (search-forward-regexp "Out \\[[0-9]+\\]" nil t))
@@ -183,7 +149,6 @@ See the definition of `create-image' for how it works."
 (ert-deftest 12-notebook-execute-current-cell-pyout-image ()
   (let ((notebook (ein:testing-get-untitled0-or-create *ein:testing-port*)))
     (ein:testing-wait-until
-     "ein:testing-get-untitled0-or-create"
      (lambda () (ein:aand (ein:$notebook-kernel notebook)
                           (ein:kernel-live-p it))))
     (with-current-buffer (ein:notebook-buffer notebook)
@@ -197,10 +162,7 @@ See the definition of `create-image' for how it works."
         ;; It seems in this case, watching `:running' does not work
         ;; well sometimes.  Probably "output reply" (iopub) comes
         ;; before "execute reply" in this case.
-        (ein:testing-wait-until "ein:worksheet-execute-cell"
-                                (lambda () (slot-value cell 'outputs))
-                                nil
-                                50)
+        (ein:testing-wait-until (lambda () (slot-value cell 'outputs)))
         ;; This cell has only one input
         (should (= (length (oref cell :outputs)) 1))
         ;; This output is a SVG image
@@ -220,17 +182,14 @@ See the definition of `create-image' for how it works."
 (ert-deftest 13-notebook-execute-current-cell-stream ()
   (let ((notebook (ein:testing-get-untitled0-or-create *ein:testing-port*)))
     (ein:testing-wait-until
-     "ein:testing-get-untitled0-or-create"
      (lambda () (ein:aand (ein:$notebook-kernel notebook)
-                          (ein:kernel-live-p it)))
-     nil 50)
+                          (ein:kernel-live-p it))))
     (with-current-buffer (ein:notebook-buffer notebook)
       (call-interactively #'ein:worksheet-insert-cell-below)
       (insert "print('Hello')")
       (let ((cell (call-interactively #'ein:worksheet-execute-cell)))
-        (ein:testing-wait-until "ein:worksheet-execute-cell"
-                                (lambda () (not (oref cell :running)))
-                                nil))
+        (ein:testing-wait-until (lambda () (not (oref cell :running)))
+                                ))
       (save-excursion
         (should-not (search-forward-regexp "Out \\[[0-9]+\\]" nil t))
         (should (search-forward-regexp "^Hello$" nil t))))))
@@ -238,28 +197,23 @@ See the definition of `create-image' for how it works."
 (ert-deftest 14-notebook-execute-current-cell-question ()
   (let ((notebook (ein:testing-get-untitled0-or-create *ein:testing-port*)))
     (ein:testing-wait-until
-     "ein:testing-get-untitled0-or-create"
      (lambda () (ein:aand (ein:$notebook-kernel notebook)
                           (ein:kernel-live-p it)))
-     nil 50)
+     )
     (with-current-buffer (ein:notebook-buffer notebook)
       (call-interactively #'ein:worksheet-insert-cell-below)
       (insert "range?")
       (let ((cell (call-interactively #'ein:worksheet-execute-cell)))
         (ein:testing-wait-until
-         "ein:worksheet-execute-cell"
-         (lambda () (not (oref cell :running)))
-         nil 50))
+         (lambda () (not (oref cell :running)))))
       (with-current-buffer (get-buffer (ein:$notebook-pager notebook))
         (should (search-forward "Docstring:"))))))
 
 (ert-deftest 15-notebook-request-help ()
   (let ((notebook (ein:testing-get-untitled0-or-create *ein:testing-port*)))
     (ein:testing-wait-until
-     "ein:testing-get-untitled0-or-create"
      (lambda () (ein:aand (ein:$notebook-kernel notebook)
-                          (ein:kernel-live-p it)))
-     nil)
+                          (ein:kernel-live-p it))))
     (with-current-buffer (ein:notebook-buffer notebook)
       (call-interactively #'ein:worksheet-insert-cell-below)
       (let ((pager-name (ein:$notebook-pager ein:%notebook%)))
@@ -269,9 +223,7 @@ See the definition of `create-image' for how it works."
         (call-interactively #'ein:pytools-request-help)
         ;; Pager buffer will be created when got the response
         (ein:testing-wait-until
-         "ein:pythools-request-help"
-         (lambda () (get-buffer pager-name))
-         nil)
+         (lambda () (get-buffer pager-name)))
         (with-current-buffer (get-buffer pager-name)
           (should (search-forward "Docstring:")))))))
 
@@ -280,12 +232,10 @@ See the definition of `create-image' for how it works."
 
   (let ((notebook (ein:testing-get-untitled0-or-create *ein:testing-port*)))
     (ein:testing-wait-until
-     "ein:testing-get-untitled0-or-create"
      (lambda () (ein:aand (ein:$notebook-kernel notebook)
-                          (ein:kernel-live-p it)))
-     nil)
+                          (ein:kernel-live-p it))))
     (cl-letf (((symbol-function 'y-or-n-p) (lambda (prompt) t)))
-      (ein:jupyter-server-stop t ein:testing-dump-server-log))
+      (ein:jupyter-server-stop t ein:testing-dump-file-server))
     (should-not (processp %ein:jupyter-server-session%))
     (cl-flet ((orphans-find (pid) (search (ein:$kernel-kernel-id (ein:$notebook-kernel notebook)) (alist-get 'args (process-attributes pid)))))
       (should-not (loop repeat 10

--- a/test/testfunc.el
+++ b/test/testfunc.el
@@ -3,6 +3,7 @@
 (require 'ein-dev)
 (require 'ein-testing)
 (require 'ein-jupyter)
+(require 'ein-notebooklist)
 (require 'deferred)
 
 (ein:log 'info "Starting jupyter notebook server.")
@@ -17,20 +18,21 @@
 (defvar *ein:testing-port* nil)
 (defvar *ein:testing-token* nil)
 
-(ein:setq-if-not ein:testing-dump-file-log "./log/testfunc.log")
-(ein:setq-if-not ein:testing-dump-file-messages "./log/testfunc.messages")
-(ein:setq-if-not ein:testing-dump-server-log  "./log/testfunc.server")
+(setq ein:testing-dump-file-log (concat default-directory "log/testfunc.log"))
+(setq ein:testing-dump-file-messages (concat default-directory "log/testfunc.messages"))
+(setq ein:testing-dump-file-server  (concat default-directory  "log/testfunc.server"))
+(setq ein:testing-dump-file-request  (concat default-directory "log/testfunc.request"))
 (setq message-log-max t)
 (setq ein:force-sync t)
 (setq ein:jupyter-server-run-timeout 120000)
 (setq ein:content-query-timeout nil)
 (setq ein:query-timeout nil)
-
-(ein:log 'info "Staring local jupyter notebook server.")
-
 (setq ein:jupyter-server-args '("--no-browser" "--debug"))
 
+(ein:dev-start-debug)
 (deferred:sync! (ein:jupyter-server-start *ein:testing-jupyter-server-command* *ein:testing-jupyter-server-directory*))
+;; (ein:testing-wait-until (lambda () (not (null (ein:notebooklist-list))))
+;;                         nil 120000 5000)
 (multiple-value-bind (url token) (ein:jupyter-server-conn-info)
   (ein:log 'info (format "testing-start-server url: %s, token: %s" url token))
   (setq *ein:testing-port* url)

--- a/tools/testein.py
+++ b/tools/testein.py
@@ -145,7 +145,7 @@ class TestRunner(BaseRunner):
         self.notebook_dir = os.path.join(EIN_ROOT, "test")
         self.lispvars = {
             'ein:testing-dump-file-log': quote(self.logpath_log),
-            'ein:testing-dump-server-log': quote(self.logpath_server),
+            'ein:testing-dump-file-server': quote(self.logpath_server),
             'ein:testing-dump-file-messages': quote(self.logpath_messages),
             'ein:log-level': self.ein_log_level,
             'ein:force-sync': "t",


### PR DESCRIPTION
Use deferred and callbacks instead of `:sync t` for tkf requests which
is known to have issues.  Query server attributes once on
notebooklist-open to avoid sequencing issue #176 (but allow Resync).
Under curl backend, a second request for the same "key" as a pending
request will abort the latter, which has resulted in a clobbered
curl-cookie-jar file, so merely warn and don't abort.

Fixes #176