### PR TITLE
Make *ein:log-all* harder to access

### DIFF
--- a/lisp/ein-log.el
+++ b/lisp/ein-log.el
@@ -29,7 +29,7 @@
 (require 'ein-core)
 
 
-(defvar ein:log-all-buffer-name "*ein:log-all*")
+(defvar ein:log-all-buffer-name " *ein:log-all*")
 
 (defvar ein:log-level-def
   '(;; debugging


### PR DESCRIPTION
I'd like to return to tkf's prepending a space character to the
`*ein:log-all*` buffer to hide it.  This might have been viewed as
suboptimal because 1) relies on the very arbitrary and arcane "space
rule" 2) developers could not easily view the buffer.

I prefer the space because 1) it's unsettling for users to have
`*ein:log-all*` appear in `list-buffers` and 2) consistency (if we
adhere to any elisp convention we should adhere to all of them by the
in-for-penny corollary).

This change, if approved, will once again make it difficult to quickly
access the `*ein:log-all*` buffer.  I personally use `M-x
ein:log-pop-to-all-buffer` or evaluate `(switch-to-buffer ein:log-all-buffer-name)`.