### PR TITLE
Turn off IPEP15 autosave by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,10 +12,7 @@ Jupyter.
           no guarantees for the safety for your notebook data.  Please make sure
           that you back-up and back-up often!
 
-.. note:: The code for testing EIN is horribly broken, but I regularly hand
-          check the code running against IPython's suite of sample
-          notebooks. It's a worse-is-better solution to problem requiring a
-          time-consuming solution.
+.. note:: The code for testing EIN is improving and we welcome more tests via the excellent ert and ecukes mechanisms.
 
 .. |build-status|
    image:: https://secure.travis-ci.org/millejoh/emacs-ipython-notebook.png?branch=master

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -32,7 +32,6 @@
 (Setup
  (setq ein:force-sync t)
  (ein:dev-start-debug)
- (setq ein:notebook-autosave-frequency 10000)
  (setq ein:testing-dump-file-log "./log/ecukes.log")
  (setq ein:testing-dump-file-messages "./log/ecukes.messages")
  (setq ein:testing-dump-server-log  "./log/ecukes.server")


### PR DESCRIPTION
My primary reason for using EIN is to avoid the peculiarities of in-browser editing, one of them being autosaves as real saves.  Jupyter's autosave philosophy is described in [IPEP 15](https://github.com/ipython/ipython/wiki/IPEP-15%3A-Autosaving-the-IPython-Notebook).

IPEP 15 observes that emacs's back-and-forth regarding "do you want to save?" is onerous not because it's wrong but because it's difficult to implement in a web client.  As emacs users we both prefer and have the luxury of saving the old-school way, that is, when we explicitly `C-x C-s`.  As it stands, EIN indiscriminately saves any errant changes in one minute, and that is rather jarring for some.