### PR TITLE
Fix ein:pytools-export-buffer

### DIFF
--- a/lisp/ein-kernel.el
+++ b/lisp/ein-kernel.el
@@ -883,7 +883,7 @@ as a string and the rest of the argument is the optional ARGS."
                          (let ((func (car packed))
                                (args (cdr packed)))
                            (when (equal msg-type "stream")
-                             (ein:aif (plist-get content :data)
+                             (ein:aif (plist-get content :text)
                                  (apply func it args)))))
                        (cons func args)))))
 

--- a/lisp/ein-pytools.el
+++ b/lisp/ein-pytools.el
@@ -363,7 +363,7 @@ Currently EIN/IPython supports exporting to the following formats:
           (json-pretty-print (point-min) (point-max)))
       (ein:kernel-request-stream
        (ein:get-kernel)
-       (format "__import__('ein').export_nb('%s', '%s')"
+       (format "__import__('ein').export_nb(r'%s', '%s')"
                json
                format)
        (lambda (export buffer)


### PR DESCRIPTION
I'd write some tests for this, but for some strange reason, `cask exec ecukes` crashes on my machine with `Wrong type argument: stringp, nil`.

It seems to be something with `(require 'espuds)` in `features/support/env.el`, because when I comment this line out, the above error goes away and I get output from ecukes (`Please implement the following step definitions [...]`), which is expected in this case.

In other projects, exactly the same combination of ecukes, espuds and Emacs versions works fine.

