### PR TITLE
remove ess dependency, introduced in bc10cea7

### DIFF
--- a/Cask
+++ b/Cask
@@ -13,7 +13,6 @@
  (depends-on "dash")
  (depends-on "cl-generic")
  (depends-on "company")
- (depends-on "ess")
  (depends-on "org-plus-contrib") ;; see https://github.com/cask/cask/issues/119
  (depends-on "markdown-mode")
  (depends-on "smartrep")

--- a/lisp/ein-cell-edit.el
+++ b/lisp/ein-cell-edit.el
@@ -26,7 +26,6 @@
 ;;; Code:
 (require 'ein-cell)
 (require 'org-src)
-(require 'ess-r-mode)
 (require 'markdown-mode)
 
 (defvar ein:src--cell nil)


### PR DESCRIPTION
ESS is a huge package, it is unclear why EIN should depend on it.