### PR TITLE
Issue #355 - remove an endless loop

### DIFF
--- a/Cask
+++ b/Cask
@@ -15,6 +15,7 @@
  (depends-on "ert-runner")
  (depends-on "ecukes")
  (depends-on "espuds")
+ (depends-on "org-plus-contrib") ;; see https://github.com/cask/cask/issues/119
  (depends-on "mocker")
  (depends-on "skewer-mode")
  (depends-on "deferred")

--- a/lisp/ob-ein.el
+++ b/lisp/ob-ein.el
@@ -34,12 +34,11 @@
 (require 'ob)
 (require 'ob-python)
 (require 'cl)
-(require 'ein-notebook)
 (require 'ein-shared-output)
-(require 'org-src nil t)
-(require 'org-element nil t)
 (require 'ein-utils)
 (require 'python)
+
+(autoload 'org-element-property "org-element")
 
 (defcustom ein:org-async-p t
   "If non-nil run ein org-babel source blocks asyncronously."
@@ -236,8 +235,9 @@ jupyter kernels.
                                      (lambda (_nb _param session kernelspec)
                                        (org-babel-ein-initiate-session session kernelspec))
                                      (list session kernelspec)))))
-      (loop do (sit-for 1.0)
-            until (ein:kernel-live-p (ein:$notebook-kernel nb)))
+      (loop repeat 4
+            until (ein:kernel-live-p (ein:$notebook-kernel nb))
+            do (sit-for 1.0))
       nb)))
 
 (defun org-babel-edit-prep:ein (babel-info)

--- a/test/test-ein-ob.el
+++ b/test/test-ein-ob.el
@@ -1,0 +1,26 @@
+(eval-when-compile (require 'cl))
+(require 'ert)
+(require 'ob-ein)
+
+
+;; Test utils
+
+;;; This is the content portion of a response fromt he content API.
+(defvar eintest:ob-src-block
+  "#+BEGIN_SRC ein :session 8888/Untitled.ipynb
+import sys
+
+a = 14500
+b = a+1000
+sys.version
+#+END_SRC
+")
+
+(ert-deftest ein:ob-aware ()
+  (let ((org-babel-load-languages (quote ((ipython . t) (ein . t)))))
+    (with-temp-buffer
+      (save-excursion
+        (org-mode)
+        (insert eintest:ob-src-block)
+        (search-backward "SRC")
+        (should (call-interactively #'org-edit-special))))))


### PR DESCRIPTION
Limit an ob-ein loop waiting for kernel after four seconds.
Add a test stub for ob-ein.
This PR does download org-src for emacs 25 for testing purposes.