### PR TITLE
Fix "Kernel is busy..." bug

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -111,7 +111,7 @@ install:
   - copy C:\projects\myproject\tools\appveyor.init.el %userprofile%\.emacs.d\init.el
   - copy C:\projects\myproject\tools\appveyor.init.el %userprofile%\.emacs
 #  - bash -lc "cd /c/projects/myproject ; bash tools/install-cask.sh"
-  - choco install gnuwin32-make.portable
+#  - choco install gnuwin32-make.portable
 
 # enable patching of AssemblyInfo.* files
 # assembly_info:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-EMACS ?= $(shell which emacs)
 SRC=$(shell cask files)
 ELCFILES = $(SRC:.el=.elc)
 
@@ -23,7 +22,7 @@ env-ipy.%:
 
 .PHONY: test-compile
 test-compile: clean autoloads
-	! ( cask build 2>&1 | awk '{if (/^ /) { gsub(/^ +/, " ", $$0); printf "%s", $$0 } else { printf "\n%s", $$0 }}' | egrep "not known|Error|free variable|error for|Use of gv-ref" )
+	! ( cask build 2>&1 | awk '{if (/^ /) { gsub(/^ +/, " ", $$0); printf "%s", $$0 } else { printf "\n%s", $$0 }}' | egrep -a "not known|Error|free variable|error for|Use of gv-ref" )
 	cask clean-elc
 
 .PHONY: quick

--- a/features/undo.feature
+++ b/features/undo.feature
@@ -173,7 +173,6 @@ Scenario: Undo needs to at least work for reopened notebooks
   Given I start the server configured "\n"
   Given I enable "ein:worksheet-enable-undo"
   Given old notebook "undo.ipynb"
-  When I press "C-<down>"
   And I type "howdy"
   And I press "RET"
   And I press "C-<down>"

--- a/lisp/ein-cell-edit.el
+++ b/lisp/ein-cell-edit.el
@@ -25,9 +25,6 @@
 
 ;;; Code:
 (require 'ein-cell)
-(require 'ess-r-mode nil t)
-(require 'org-src nil t)
-(require 'markdown-mode nil t)
 
 (autoload 'markdown-mode "markdown-mode")
 (autoload 'R-mode "ess-r-mode")

--- a/lisp/ein-classes.el
+++ b/lisp/ein-classes.el
@@ -348,7 +348,7 @@ auto-execution mode flag in the connected buffer is `t'.")))
   ((status :initarg :status :initform nil)
    (message :initarg :message :initform nil)
    (s2m :initarg :s2m))
-  "Hold status and it's string representation (message).")
+  "Hold status and its string representation (message).")
 
 (defclass ein:notification-tab ()
   ((get-list :initarg :get-list :type function)

--- a/lisp/ein-completer.el
+++ b/lisp/ein-completer.el
@@ -34,6 +34,7 @@
 (require 'ein-log)
 (require 'ein-subpackages)
 (require 'ein-kernel)
+(require 'dash)
 
 (defun ein:completer-choose ()
   (require 'ein-ac)
@@ -130,23 +131,19 @@ notebook buffers and connected buffers."
 (defvar *ein:oinfo-cache* (make-hash-table :test #'equal))
 
 (defun ein:completions--get-oinfo (obj)
-  (let ((d (deferred:new #'identity))
-        (kernel (ein:get-kernel)))
+  (lexical-let ((d (deferred:new #'identity))
+                (kernel (ein:get-kernel)))
     (if (ein:kernel-live-p kernel)
         (ein:kernel-execute
          kernel
          (format "__import__('ein').print_object_info_for(%s)" obj)
          (list
-          :output (cons (lambda (d &rest args) (deferred:callback-post d args))
-                        d)))
+          :output `(,(lambda (d &rest args) (deferred:callback-post d args)) . ,d)))
       (deferred:callback-post d (list nil nil)))
     d))
 
-(defun ein:clear-oinfo-cache ()
-  (clrhash *ein:oinfo-cache*))
-
 (defun ein:completions--build-oinfo-cache (objs)
-  (dolist (o objs)
+  (dolist (o (-non-nil objs))
     (deferred:$
       (deferred:next
         (lambda ()
@@ -156,26 +153,23 @@ notebook buffers and connected buffers."
           (ein:completions--prepare-oinfo output o))))))
 
 (defun ein:completions--prepare-oinfo (output obj)
-  (condition-case _
+  (condition-case err
       (destructuring-bind (msg-type content _) output
         (ein:case-equal msg-type
-          (("stream" "display_data")
-           (let* ((oinfo (ein:json-read-from-string (plist-get content :text))))
-             (setf (gethash obj *ein:oinfo-cache*) oinfo)))))
-    (error (setf (gethash obj *ein:oinfo-cache*) ""))))
+          (("stream" "display_data" "pyout" "execute_result")
+           (setf (gethash obj *ein:oinfo-cache*) (plist-get content :text)))
+          (("error" "pyerr")
+           (ein:log 'error "ein:completions--prepare-oinfo: %S" (plist-get content :traceback)))))
+    (error (ein:log 'error "ein:completions--prepare-oinfo: [%s] %s" err obj)
+           (setf (gethash obj *ein:oinfo-cache*) :json-false))))
 
 ;;; Support for Eldoc
 
 (defun ein:completer--get-eldoc-signature ()
-  (let* ((func (ein:function-at-point))
-         (oinfo (gethash func *ein:oinfo-cache* nil)))
-    (if (not oinfo)
-        (ein:completions--build-oinfo-cache (list func))
-      (plist-get oinfo :definition))))
-
-(defun ein:notebook--enable-eldoc ()
-  (set (make-local-variable 'eldoc-documentation-function)
-       #'ein:completer--get-eldoc-signature))
+  (let ((func (ein:function-at-point)))
+    (ein:aif (gethash func *ein:oinfo-cache*)
+        (ein:kernel-construct-defstring it)
+      (ein:completions--build-oinfo-cache (list func)))))
 
 (provide 'ein-completer)
 

--- a/lisp/ein-completer.el
+++ b/lisp/ein-completer.el
@@ -131,8 +131,8 @@ notebook buffers and connected buffers."
 (defvar *ein:oinfo-cache* (make-hash-table :test #'equal))
 
 (defun ein:completions--get-oinfo (obj)
-  (lexical-let ((d (deferred:new #'identity))
-                (kernel (ein:get-kernel)))
+  (let ((d (deferred:new #'identity))
+        (kernel (ein:get-kernel)))
     (if (ein:kernel-live-p kernel)
         (ein:kernel-execute
          kernel

--- a/lisp/ein-connect.el
+++ b/lisp/ein-connect.el
@@ -368,7 +368,7 @@ notebook."
   (define-key map "\C-c\C-l" 'ein:connect-reload-buffer)
   (define-key map "\C-c\C-r" 'ein:connect-eval-region)
   (define-key map (kbd "C-:") 'ein:shared-output-eval-string)
-  (define-key map "\C-c\C-f" 'ein:pytools-request-tooltip-or-help)
+  (define-key map "\C-c\C-h" 'ein:pytools-request-tooltip-or-help)
   (define-key map "\C-c\C-i" 'ein:completer-complete)
   (define-key map "\C-c\C-z" 'ein:connect-pop-to-notebook)
   (define-key map "\C-c\C-a" 'ein:connect-toggle-autoexec)

--- a/lisp/ein-core.el
+++ b/lisp/ein-core.el
@@ -136,7 +136,7 @@ the source is in git repository."
     ein:version))
 
 
-;;; Server attribute getters.  Not sure if these should be here.
+;;; Server attribute getters.  These should be moved to ein-open.el
 
 (defvar *ein:notebook-version* (make-hash-table :test #'equal)
   "url-or-port to major notebook version")
@@ -191,7 +191,7 @@ the source is in git repository."
         (ein:log 'verbose "Retry kernelspecs #%s in response to %s" iteration (request-response-status-code response))
         (ein:query-kernelspecs url-or-port callback (1+ iteration)))
     (ein:log 'error
-             "ein:query-kernelspecs-error %s: ERROR %s DATA %s" url-or-port (car error-thrown) (cdr error-thrown))))
+             "ein:query-kernelspecs--error %s: ERROR %s DATA %s" url-or-port (car error-thrown) (cdr error-thrown))))
 
 (defun* ein:query-kernelspecs--complete (url-or-port callback &key data response
                                                      &allow-other-keys 

--- a/lisp/ein-file.el
+++ b/lisp/ein-file.el
@@ -38,7 +38,7 @@
 (defun ein:file-open (url-or-port path)
   (interactive
    (ein:notebooklist-parse-nbpath (ein:notebooklist-ask-path "file")))
-  (ein:content-query-contents url-or-port path #'ein:file-open-finish))
+  (ein:content-query-contents url-or-port path #'ein:file-open-finish nil))
 
 (defun ein:file-open-finish (content)
   (with-current-buffer (get-buffer-create (ein:file-buffer-name (ein:$content-url-or-port content)

--- a/lisp/ein-notebook.el
+++ b/lisp/ein-notebook.el
@@ -341,7 +341,8 @@ notebook buffer.  Let's warn for now to see who is doing this.
           (funcall callback0))
       (ein:content-query-contents url-or-port path
                                   (apply-partially #'ein:notebook-open--callback
-                                                   notebook callback0)))
+                                                   notebook callback0) 
+                                  nil))
     notebook))
 
 (defun ein:notebook-open--callback (notebook callback0 content)

--- a/lisp/ein-notebook.el
+++ b/lisp/ein-notebook.el
@@ -188,6 +188,7 @@ Current buffer for these functions is set to the notebook buffer.")
 
 (ein:deflocal ein:%notebook% nil
   "Buffer local variable to store an instance of `ein:$notebook'.")
+
 (define-obsolete-variable-alias 'ein:notebook 'ein:%notebook% "0.1.2")
 
 
@@ -299,6 +300,8 @@ will be updated with kernel's cwd."
 (defun ein:notebook-open--decorate-callback (notebook existing callback)
   "In addition to CALLBACK, also pop-to-buffer the new notebook, and save to disk the kernelspec metadata."
   (apply-partially (lambda (notebook* created callback*)
+                     (with-current-buffer (ein:notebook-buffer notebook*)
+                       (ein:worksheet-focus-cell))
                      (pop-to-buffer (ein:notebook-buffer notebook*))
                      (ein:aif (ein:$notebook-kernelspec notebook*)
                          (progn
@@ -604,7 +607,6 @@ This is equivalent to do ``C-c`` in the console program."
     ;; Now that major-mode is set, set buffer local variables:
     (ein:notebook--notification-setup notebook)
     (ein:notebook-setup-kill-buffer-hook)
-    (ein:notebook--enable-eldoc)
     (setq ein:%notebook% notebook)))
 
 (defun ein:notebook--notification-setup (notebook)
@@ -1286,10 +1288,11 @@ Use simple `python-mode' based notebook mode when MuMaMo is not installed::
                          (const :tag "Plain" ein:notebook-plain-mode)))
   :group 'ein)
 
-(defcustom ein:notebook-mode-hook nil
+(defcustom ein:notebook-mode-hook
+  '(ein:worksheet-imenu-setup ein:worksheet-reinstall-which-cell-hook)
   "Hook for `ein:notebook-mode'.
 This hook is run regardless the actual major mode used."
-  :type 'hook
+  :type '(repeat function)
   :group 'ein)
 
 (defun ein:notebook-choose-mode ()
@@ -1497,6 +1500,20 @@ This hook is run regardless the actual major mode used."
       ))
   map)
 
+(defun ein:notebook-configure-eldoc ()
+  "eldoc comments say: Major modes for other languages may use ElDoc by defining an
+appropriate function as the buffer-local value of `eldoc-documentation-function'."
+  ;; TODO
+  (when nil
+    (require 'eldoc nil t)
+    (if (boundp 'eldoc-documentation-function)
+        (setq-local eldoc-documentation-function 
+                    (apply-partially (lambda (oldfun &rest args)
+                                       (or (apply #'ein:completer--get-eldoc-signature args)
+                                           (apply oldfun args)))
+                                     eldoc-documentation-function))
+      (setq-local eldoc-documentation-function #'ein:completer--get-eldoc-signature))))
+
 (defun ein:notebook-mode ()
   (funcall (ein:notebook-choose-mode))
   (case ein:completion-backend
@@ -1519,10 +1536,8 @@ This hook is run regardless the actual major mode used."
       (define-key ein:notebook-mode-map it 'anything-ein-kernel-history))
   (ein:notebook-minor-mode +1)
   (setq indent-tabs-mode nil) ;; Being T causes problems with Python code.
+  (ein:notebook-configure-eldoc)
   (run-hooks 'ein:notebook-mode-hook))
-
-(add-hook 'ein:notebook-mode-hook 'ein:worksheet-imenu-setup)
-(add-hook 'ein:notebook-mode-hook 'ein:worksheet-reinstall-which-cell-hook)
 
 (define-minor-mode ein:notebook-minor-mode
   "Minor mode to install `ein:notebook-mode-map' for `ein:notebook-mode'."

--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -219,7 +219,7 @@ port the instance is running on."
                                       (ein:crib-token--all-local-tokens))))))
          (url-or-port (let ((ido-report-no-match nil)
                             (ido-use-faces nil))
-                        (ido-completing-read (format "URL or port [%s]: " default)
+                        (ido-completing-read "URL or port: "
                                              url-or-port-list
                                              nil nil nil nil
                                              default))))
@@ -743,7 +743,7 @@ Notebook list data is passed via the buffer local variable
   (remove-overlays)
 
   (let ((url-or-port (ein:$notebooklist-url-or-port ein:%notebooklist%)))
-    (ein:content-query-sessions url-or-port
+    (ein:content-query-sessions url-or-port nil
                                 (apply-partially #'ein:notebooklist-render--finish nb-version url-or-port))))
 
 (defun ein:notebooklist-render--finish (nb-version url-or-port sessions)

--- a/lisp/ein-notification.el
+++ b/lisp/ein-notification.el
@@ -57,7 +57,8 @@ S-mouse-1/3 (Shift + left/right click): move this tab to left/right"
 (defmethod ein:notification-status-set ((ns ein:notification-status) status)
   (let* ((message (cdr (assoc status (slot-value ns 's2m)))))
     (setf (slot-value ns 'status) status)
-    (setf (slot-value ns 'message) message)))
+    (setf (slot-value ns 'message) message)
+    (force-mode-line-update)))
 
 (defmethod ein:notification-bind-events ((notification ein:notification)
                                          events)

--- a/test/test-ein-notebooklist.el
+++ b/test/test-ein-notebooklist.el
@@ -3,8 +3,8 @@
 
 (defun eintest:notebooklist-make-empty (&optional url-or-port)
   "Make empty notebook list buffer."
-  (flet ((ein:need-kernelspecs (url-or-port))
-         (ein:content-query-sessions (session-hash url-or-port)))
+  (cl-letf (((symbol-function 'ein:need-kernelspecs) #'ignore)
+            ((symbol-function 'ein:content-query-sessions) #'ignore))
     (ein:notebooklist-open--finish nil
      (make-ein:$content :url-or-port (or url-or-port ein:testing-notebook-dummy-url)
                         :notebook-version 3

--- a/test/testfunc.el
+++ b/test/testfunc.el
@@ -19,13 +19,6 @@
 (setq ein:testing-dump-file-messages (concat default-directory "log/testfunc.messages"))
 (setq ein:testing-dump-file-server  (concat default-directory  "log/testfunc.server"))
 (setq ein:testing-dump-file-request  (concat default-directory "log/testfunc.request"))
-(setq message-log-max t)
-(setq ein:force-sync t)
-(setq ein:jupyter-server-run-timeout 120000)
-(setq ein:content-query-timeout nil)
-(setq ein:query-timeout nil)
-(setq ein:jupyter-server-args '("--no-browser" "--debug"))
-
 (ein:dev-start-debug)
 (ein:jupyter-server-start *ein:testing-jupyter-server-command* *ein:testing-jupyter-server-directory*)
 (ein:testing-wait-until (lambda () (ein:notebooklist-list)) nil 15000 1000)


### PR DESCRIPTION
One line change to fix longstanding bugbear of header line not 
updating after cell execution (keeps saying "Kernel is busy").

The bug does not manifest when running with `ein:debug` true since
EMACS's display loop updates more frequently with debug messages.

In tracking this bug, noticed eldoc support isn't quite there.
`__import__('ein').print_object_info_for(%s)` appears in
`ein-completer` and `ein-pytools`, and is not valid python
afaict.  Took a few steps to make it whole, but still incomplete.

Also make inroads on #239 .  