### PR TITLE
Follow up to #239

### DIFF
--- a/lisp/ein-contents-api.el
+++ b/lisp/ein-contents-api.el
@@ -119,8 +119,6 @@ global setting.  For global setting and more information, see
     (if (<= (ein:need-notebook-version url-or-port) 2)
         (setq content (ein:new-content-legacy url-or-port path data))
       (setq content (ein:new-content url-or-port path data)))
-    (ein:aif response
-        (setf (ein:$content-url-or-port content) (ein:get-response-redirect it)))
     (when callback 
       (funcall callback content))))
 

--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -567,9 +567,7 @@ You may find the new one in the notebook list." error)
   "Render the header (for ipython>=3)."
   (with-current-buffer (ein:notebooklist-get-buffer url-or-port)
     (widget-insert
-     (if (< (ein:$notebooklist-api-version ein:%notebooklist%) 4)
-         (format "IPython v%s Notebook list (%s)\n\n" (ein:$notebooklist-api-version ein:%notebooklist%) url-or-port)
-       (format "Jupyter v%s Notebook list (%s)\n\n" (ein:$notebooklist-api-version ein:%notebooklist%) url-or-port)))
+     (format "Notebook v%s (%s)\n\n" (ein:$notebooklist-api-version ein:%notebooklist%) url-or-port))
 
     (let ((breadcrumbs (generate-breadcrumbs (ein:$notebooklist-path ein:%notebooklist%))))
       (dolist (p breadcrumbs)


### PR DESCRIPTION
One line change to avoid reassignment of url-or-port upon redirect.
Commit e226b30 may have had good reasons to do this, but the original
url-or-port needs to remain sacrosanct as we key off it in several
important hash tables.

With this change, ein access to coursera appears to work quite
nicely.