### PR TITLE
Clean up websocket callbacks

### DIFF
--- a/features/notebook.feature
+++ b/features/notebook.feature
@@ -1,6 +1,21 @@
 @autosave
-Scenario: opened notebook
-  Given old notebook "undo.ipynb"
+Scenario: try autosaving
+  Given new default notebook
   And I call "ein:notebook-enable-autosaves"
-  And I switch to log expr "ein:log-all-buffer-name"
   Then I should see message "ein:notebook-autosave-frequency is 0"
+
+@reconnect
+Scenario: kernel restart succeeds
+  Given new default notebook
+  When I type "import math"
+  And I wait for cell to execute
+  And I kill processes like "websocket"
+  And I switch to log expr "ein:log-all-buffer-name"
+  Then I should see "WS closed unexpectedly"
+  And I switch to buffer like "Untitled"
+  And header says "Kernel requires restart C-c C-r"
+  And I press "C-c C-r"
+  And I wait for the smoke to clear
+  And header does not say "Kernel requires restart C-c C-r"
+  
+  

--- a/features/notebook.feature
+++ b/features/notebook.feature
@@ -17,5 +17,11 @@ Scenario: kernel restart succeeds
   And I press "C-c C-r"
   And I wait for the smoke to clear
   And header does not say "Kernel requires restart C-c C-r"
-  
+  And I clear log expr "ein:log-all-buffer-name"
+  And I force restart kernel
+  And I switch to log expr "ein:log-all-buffer-name"
+  Then I should not see "[warn]"
+  And I should not see "[error]"
+  And I should see "ein:kernel-start--complete"
+
   

--- a/features/notebooklist.feature
+++ b/features/notebooklist.feature
@@ -1,9 +1,3 @@
-Scenario: No warnings
-Given I switch to log expr "ein:log-all-buffer-name"
-Then I should see "[info]"
-And I should not see "[warn]"
-And I should not see "[error]"
-
 Scenario: Breadcrumbs
   Given I am in notebooklist buffer
   When I click on dir "step-definitions"

--- a/features/step-definitions/ein-steps.el
+++ b/features/step-definitions/ein-steps.el
@@ -8,6 +8,11 @@
         (let ((equal-p (string= says (slot-value (slot-value ein:%notification% 'kernel) 'message))))
           (cl-assert (if negate (not equal-p) equal-p)))))
 
+(When "I force restart kernel$"
+      (lambda ()
+        (ein:notebook-restart-kernel ein:%notebook%)
+        (And "I wait for the smoke to clear")))
+
 (When "I kill processes like \"\\(.+\\)\"$"
       (lambda (substr)
         (mapc (lambda (p) (if (search substr (process-name p)) (delete-process p))) 

--- a/lisp/ein-classes.el
+++ b/lisp/ein-classes.el
@@ -376,6 +376,8 @@ auto-execution mode flag in the connected buffer is `t'.")))
      :s2m
      '((status_idle.Kernel . nil)
        (status_busy.Kernel . "Kernel is busy...")
+       (status_restarted.Kernel . "Kernel restarted")
+       (status_restarting.Kernel . "Kernel restarting...")
        (status_dead.Kernel . "Kernel requires restart C-c C-r")))
     :type ein:notification-status))
   "Notification widget for Notebook.")

--- a/lisp/ein-classes.el
+++ b/lisp/ein-classes.el
@@ -89,27 +89,12 @@
   "A wrapper object of `websocket'.
 
 `ein:$websocket-ws'               : an instance returned by `websocket-open'
-
-`ein:$websocket-onmessage'        : function called with (PACKET &rest ARGS)'
-`ein:$websocket-onclose'          : function called with (WEBSOCKET &rest ARGS)'
-`ein:$websocket-onopen'           : function called with (&rest ARGS)'
-
-`ein:$websocket-onmessage-args'   : optional arguments for onmessage callback'
-`ein:$websocket-onclose-args'     : optional arguments for onclose callback'
-`ein:$websocket-onopen-args'      : optional arguments for onopen callback'
-
+`ein:$websocket-kernel'           : kernel at the time of instantiation
 `ein:$websocket-closed-by-client' : t/nil'
 "
   ws
-  onmessage
-  onmessage-args
-  onclose
-  onclose-args
-  onopen
-  onopen-args
+  kernel
   closed-by-client)
-
-
 
 
 ;;; Notebook
@@ -255,12 +240,11 @@
   kernel-id
   shell-channel
   iopub-channel
-  channels                              ; For IPython 3.x+
+  websocket                             ; For IPython 3.x+
   base-url                              ; /api/kernels/
   kernel-url                            ; /api/kernels/<KERNEL-ID>
   ws-url                                ; ws://<URL>[:<PORT>]
   stdin-activep
-  running
   username
   msg-callbacks
   ;; FIXME: Use event instead of hook.
@@ -392,7 +376,7 @@ auto-execution mode flag in the connected buffer is `t'.")))
      :s2m
      '((status_idle.Kernel . nil)
        (status_busy.Kernel . "Kernel is busy...")
-       (status_dead.Kernel . "Kernel is dead. Need restart.")))
+       (status_dead.Kernel . "Kernel requires restart C-c C-r")))
     :type ein:notification-status))
   "Notification widget for Notebook.")
 

--- a/lisp/ein-contents-api.el
+++ b/lisp/ein-contents-api.el
@@ -103,7 +103,7 @@ global setting.  For global setting and more information, see
   (if (< iteration 3)
       (progn
         (ein:log 'verbose "Retry content-query-contents #%s in response to %s" iteration (request-response-status-code response))
-        (sleep-for 0 (* (1+ iteration) 200))
+        (sleep-for 0 (* (1+ iteration) 500))
         (ein:content-query-contents url-or-port path callback errback (1+ iteration)))
     (ein:log 'error "ein:content-query-contents--error %s REQUEST-STATUS %s DATA %s" (concat (file-name-as-directory url-or-port) path) symbol-status (cdr error-thrown))
     (when errback (funcall errback nil))))
@@ -393,6 +393,7 @@ global setting.  For global setting and more information, see
   (if (< iteration 3)
       (progn
         (ein:log 'verbose "Retry sessions #%s in response to %s" iteration (request-response-status-code response))
+        (sleep-for 0 (* (1+ iteration) 500))
         (ein:content-query-sessions url-or-port callback errback (1+ iteration)))
     (ein:log 'error "ein:content-query-sessions--error %s: ERROR %s DATA %s" url-or-port (car error-thrown) (cdr error-thrown))
     (when errback (funcall errback nil))))

--- a/lisp/ein-dev.el
+++ b/lisp/ein-dev.el
@@ -160,7 +160,7 @@ callback (`websocket-callback-debug-on-error') is enabled."
   (interactive)
   (pop-to-buffer
    (websocket-get-debug-buffer-create
-    (ein:$websocket-ws (ein:$kernel-channels
+    (ein:$websocket-ws (ein:$kernel-websocket
                         (ein:$notebook-kernel ein:%notebook%))))))
 
 (defun ein:dev-pop-to-debug-shell ()

--- a/lisp/ein-notification.el
+++ b/lisp/ein-notification.el
@@ -58,7 +58,7 @@ S-mouse-1/3 (Shift + left/right click): move this tab to left/right"
   (let* ((message (cdr (assoc status (slot-value ns 's2m)))))
     (setf (slot-value ns 'status) status)
     (setf (slot-value ns 'message) message)
-    (force-mode-line-update)))
+    (force-mode-line-update t)))
 
 (defmethod ein:notification-bind-events ((notification ein:notification)
                                          events)
@@ -94,11 +94,9 @@ where NS is `:kernel' or `:notebook' slot of NOTIFICATION."
                  notification)
   (ein:events-on events
                  'status_restarting.Kernel
-                 #'ein:notification--fadeout-callback
-                 (list (slot-value notification 'kernel)
-                       "Restarting kernel..."
-                       'status_restarting.Kernel
-                       'status_idle.Kernel)))
+                 #'ein:notification--callback
+                 (list (slot-value notification 'kernel) 
+                       'status_restarting.Kernel)))
 
 (defun ein:notification--callback (packed data)
   (let ((ns (car packed))

--- a/lisp/ein-websocket.el
+++ b/lisp/ein-websocket.el
@@ -93,7 +93,7 @@
                              :on-message on-message
                              :on-close on-close
                              :on-error (lambda (ws action err)
-                                         (ein:log 'error "WS action [%s] %s (%s)" 
+                                         (ein:log 'info "WS action [%s] %s (%s)" 
                                                   err action (websocket-url ws)))))
          (websocket (make-ein:$websocket :ws ws :kernel kernel :closed-by-client nil)))
     (setf (websocket-client-data ws) websocket)

--- a/lisp/ein-worksheet.el
+++ b/lisp/ein-worksheet.el
@@ -1001,7 +1001,7 @@ Do not clear input prompts when the prefix argument is given."
                                    (list (cons slot
                                                (websocket-ready-state
                                                 (ein:$websocket-ws channel)))))))
-                          '(ein:$kernel-channels
+                          '(ein:$kernel-websocket
                             ein:$kernel-shell-channel
                             ein:$kernel-iopub-channel)))))
 

--- a/test/test-ein-kernel.el
+++ b/test/test-ein-kernel.el
@@ -4,25 +4,25 @@
 (require 'ein-kernel)
 (require 'ein-testing-kernel)
 
-
 (defun eintest:kernel-new (port)
   (ein:kernel-new port "/api/kernels"
                   (get-buffer-create "*eintest: dummy for kernel test*")))
 
 (ert-deftest ein:kernel-restart-check-url ()
-  (let* ((kernel (eintest:kernel-new 8888))
-         (kernel-id "KERNEL-ID")
-         (desired-url "http://127.0.0.1:8888/api/sessions/KERNEL-ID")
-         (dummy-response (make-request-response))
-         got-url)
-    (flet ((request (url &rest ignore) (setq got-url url) dummy-response)
-           (set-process-query-on-exit-flag (process flag))
-           (ein:kernel-stop-channels (&rest ignore))
-           (ein:websocket (&rest ignore) (make-ein:$websocket))
-           (ein:events-trigger (&rest ignore))
-           (ein:get-notebook-or-error () (ein:get-notebook)))
-      (ein:kernel--kernel-started
-       kernel :data (list :ws_url "ws://127.0.0.1:8888" :id kernel-id))
+  (lexical-let* ((kernel (eintest:kernel-new 8888))
+                 (kernel-id "KERNEL-ID")
+                 (desired-url "http://127.0.0.1:8888/api/sessions/KERNEL-ID")
+                 (dummy-response (make-request-response))
+                 got-url)
+    (cl-letf (((symbol-function 'request) 
+               (lambda (url &rest ignore) (setq got-url url) dummy-response))
+              ((symbol-function 'set-process-query-on-exit-flag) #'ignore)
+              ((symbol-function 'ein:kernel-stop-channels) #'ignore)
+              ((symbol-function 'ein:websocket) (lambda (&rest ignore) (make-ein:$websocket :ws nil :kernel kernel :closed-by-client nil)))
+              ((symbol-function 'ein:events-trigger) #'ignore)
+              ((symbol-function 'ein:get-notebook-or-error) (lambda () (ein:get-notebook))))
+      (ein:kernel-start--success
+       kernel nil :data (list :ws_url "ws://127.0.0.1:8888" :id kernel-id))
       (ein:kernel-restart kernel)
       (should (equal got-url desired-url)))))
 
@@ -35,9 +35,10 @@
     (flet ((request (url &rest ignore) (setq got-url url) dummy-response)
            (set-process-query-on-exit-flag (process flag))
            (ein:kernel-stop-channels (&rest ignore))
-           (ein:websocket (&rest ignore) (make-ein:$websocket)))
-      (ein:kernel--kernel-started
-       kernel :data (list :ws_url "ws://127.0.0.1:8888" :id kernel-id))
+           (ein:websocket (url kernel on-message on-close on-open) (make-ein:$websocket :ws nil :kernel kernel :closed-by-client nil))
+           (ein:websocket-open-p (websocket) t))
+      (ein:kernel-start--success
+       kernel nil :data (list :ws_url "ws://127.0.0.1:8888" :id kernel-id))
       (ein:kernel-interrupt kernel)
       (should (equal got-url desired-url)))))
 
@@ -50,10 +51,10 @@
     (flet ((request (url &rest ignore) (setq got-url url) dummy-response)
            (set-process-query-on-exit-flag (process flag))
            (ein:kernel-stop-channels (&rest ignore))
-           (ein:websocket (&rest ignore) (make-ein:$websocket)))
-      (ein:kernel--kernel-started
-       kernel :data (list :ws_url "ws://127.0.0.1:8888" :id kernel-id))
-      (ein:kernel-kill kernel)
+           (ein:websocket (url kernel on-message on-close on-open) (make-ein:$websocket :ws nil :kernel kernel :closed-by-client nil)))
+      (ein:kernel-start--success
+       kernel nil :data (list :ws_url "ws://127.0.0.1:8888" :id kernel-id))
+      (ein:kernel-delete kernel)
       (should (equal got-url desired-url)))))
 
 

--- a/test/test-ein-notebook.el
+++ b/test/test-ein-notebook.el
@@ -968,9 +968,9 @@ defined."
           ((ein:kernel-live-p
             (kernel)
             ((:input (list kernel) :output t)))
-           (ein:kernel-kill
-            (kernel &optional callback cbargs)
-            ((:input (list kernel #'ein:notebook-close (list notebook))))))
+           (ein:kernel-delete
+            (kernel &optional callback)
+            ((:input (list kernel (apply-partially #'ein:notebook-close notebook))))))
         (call-interactively #'ein:notebook-kill-kernel-then-close-command))
       (should (buffer-live-p buffer))
       ;; Pretend that `ein:notebook-close' is called.

--- a/test/test-ein-notebooklist.el
+++ b/test/test-ein-notebooklist.el
@@ -5,7 +5,7 @@
   "Make empty notebook list buffer."
   (cl-letf (((symbol-function 'ein:need-kernelspecs) #'ignore)
             ((symbol-function 'ein:content-query-sessions) #'ignore))
-    (ein:notebooklist-open--finish nil
+    (ein:notebooklist-open--finish (or url-or-port ein:testing-notebook-dummy-url) nil 
      (make-ein:$content :url-or-port (or url-or-port ein:testing-notebook-dummy-url)
                         :notebook-version 3
                         :path ""))))

--- a/test/test-ein-notification.el
+++ b/test/test-ein-notification.el
@@ -59,9 +59,10 @@
             notebook_create_checkpoint.Notebook
             notebook_checkpoint_created.Notebook
             execution_count.Kernel
-            status_restarting.Kernel
             status_idle.Kernel
             status_busy.Kernel
+            status_restarting.Kernel
+            status_restarted.Kernel
             status_dead.Kernel
             ))
          (callbacks (oref events :callbacks)))

--- a/test/test-ein-notification.el
+++ b/test/test-ein-notification.el
@@ -44,7 +44,7 @@
                                  'notebook_saving.Notebook)
     (should (string-prefix-p
              (concat "IP[y]: Saving Notebook... | "
-                     "Kernel is dead. Need restart. | "
+                     "Kernel requires restart C-c C-r | "
                      "/1\\ /2\\ /3\\ [+]") (ein:header-line)))))
 
 (ert-deftest ein:notification-and-events ()


### PR DESCRIPTION
Coursera appears to kill websockets every minute or so, and I'm
observing firsthand the buggy behaviors described in #356 and #363. This PR
cleans up the websocket code and kernel restart logic.  Removed
backwards compatibility for the v2 messaging api
as keeping it in the presence of the refactoring would make it more
broken that it already was.