### PR TITLE
update the code base to avoid compilation warnings about obsolete functions

### DIFF
--- a/lisp/debug-ein.el
+++ b/lisp/debug-ein.el
@@ -30,7 +30,7 @@
 (require 'ein-dev)
 
 (ein:dev-start-debug)
-(ein:notebooklist-open)
+;; (ein:notebooklist-login ...)
 
 
 ;;; Extra stuff

--- a/lisp/ein-cell.el
+++ b/lisp/ein-cell.el
@@ -282,7 +282,7 @@ a number will limit the number of lines in a cell output."
   cell)
 
 (defmethod ein:cell-init ((cell ein:headingcell) data) ;; FIXME: Was :after method
-  (call-next-method)
+  (cl-call-next-method)
   (ein:aif (plist-get data :level)
       (setf (slot-value cell 'level) it))
   cell)
@@ -291,27 +291,27 @@ a number will limit the number of lines in a cell output."
   (let ((new (ein:cell-from-type type)))
     ;; copy attributes
     (loop for k in '(read-only ewoc)
-          do (set-slot-value new k (slot-value cell k)))
+      do (setf (slot-value new k) (slot-value cell k)))
     ;; copy input
-    (set-slot-value new 'input (if (ein:cell-active-p cell)
-                                   (ein:cell-get-text cell)
-                                 (slot-value cell 'input)))
+    (setf (slot-value new 'input) (if (ein:cell-active-p cell)
+                                      (ein:cell-get-text cell)
+                                    (slot-value cell 'input)))
     ;; copy slidetype
-    (set-slot-value new 'slidetype (slot-value cell 'slidetype))
+    (setf (slot-value new 'slidetype) (slot-value cell 'slidetype))
     ;; copy output when the new cell has it
     (when (memq :output (slot-value new 'element-names))
-      (set-slot-value new 'outputs (mapcar 'identity (slot-value cell 'outputs))))
+      (setf (slot-value new 'outputs) (mapcar 'identity (slot-value cell 'outputs))))
     new))
 
 (defmethod ein:cell-convert ((cell ein:codecell) type)
-  (let ((new (call-next-method)))
-    (when (and (ein:codecell-child-p new)
+  (let ((new (cl-call-next-method)))
+    (when (and (cl-typep new 'ein:codecell)
                (slot-boundp cell :kernel))
       (setf (slot-value new 'kernel) (slot-value cell 'kernel)))
     new))
 
 (defmethod ein:cell-convert ((cell ein:headingcell) type)
-  (let ((new (call-next-method)))
+  (let ((new (cl-call-next-method)))
     (when (ein:headingcell-p new)
       (setf (slot-value new 'level) (slot-value cell 'level)))
     new))
@@ -397,14 +397,14 @@ a number will limit the number of lines in a cell output."
          (ein:aif (plist-get element :output)
              (car (last it))
            (plist-get element :input)))
-        (t (call-next-method))))))
+        (t (cl-call-next-method))))))
 
 (defmethod ein:cell-element-get ((cell ein:textcell) prop &rest args)
   (let ((element (slot-value cell 'element)))
     (case prop
       (:after-input (plist-get element :footer))
       (:before-input (plist-get element :prompt))
-      (t (call-next-method)))))
+      (t (cl-call-next-method)))))
 
 (defmethod ein:cell-all-element ((cell ein:basecell))
   (list (ein:cell-element-get cell :prompt)
@@ -412,7 +412,7 @@ a number will limit the number of lines in a cell output."
         (ein:cell-element-get cell :footer)))
 
 (defmethod ein:cell-all-element  ((cell ein:codecell))
-  (append (call-next-method)
+  (append (cl-call-next-method)
           (ein:cell-element-get cell :output)))
 
 (defmethod ein:cell-language ((cell ein:basecell))
@@ -1147,7 +1147,7 @@ prettified text thus be used instead of HTML type."
       (metadata . ,metadata))))
 
 (defmethod ein:cell-to-json ((cell ein:headingcell) &optional discard-output)
-  (let ((json (call-next-method)))
+  (let ((json (cl-call-next-method)))
     (append json `((level . ,(slot-value cell 'level))))))
 
 (defmethod ein:cell-next ((cell ein:basecell))
@@ -1155,7 +1155,7 @@ prettified text thus be used instead of HTML type."
   (ein:aif (ewoc-next (slot-value cell 'ewoc)
                       (ein:cell-element-get cell :footer))
       (let ((cell (ein:$node-data (ewoc-data it))))
-        (when (ein:basecell-child-p cell)
+        (when (cl-typep cell 'ein:basecell)
           cell))))
 
 (defmethod ein:cell-prev ((cell ein:basecell))
@@ -1163,7 +1163,7 @@ prettified text thus be used instead of HTML type."
   (ein:aif (ewoc-prev (slot-value cell 'ewoc)
                       (ein:cell-element-get cell :prompt))
       (let ((cell (ein:$node-data (ewoc-data it))))
-        (when (ein:basecell-child-p cell)
+        (when (cl-typep cell 'ein:basecell)
           cell))))
 
 

--- a/lisp/ein-events.el
+++ b/lisp/ein-events.el
@@ -44,8 +44,8 @@
     (ein:log 'info "Unknown event: %S" event-type)))
 
 
-(defmethod ein:events-on ((events ein:events) event-type
-                          callback &optional arg)
+(cl-defmethod ein:events-on ((events ein:events) event-type
+                             callback &optional arg)
   "Set event trigger hook.
 
 When EVENT-TYPE is triggered on the event handler EVENTS,

--- a/lisp/ein-helm.el
+++ b/lisp/ein-helm.el
@@ -66,6 +66,7 @@
 
 This variable applies to both `helm-ein-kernel-history' and
 `anything-ein-kernel-history'."
+  :type 'boolean
   :group 'ein)
 
 (defun ein:helm-kernel-history-search-construct-pattern (pattern)

--- a/lisp/ein-hy.el
+++ b/lisp/ein-hy.el
@@ -26,7 +26,7 @@
 (require 'cl)
 (require 'ein-classes)
 
-(defmethod ein:cell-insert-prompt ((cell ein:hy-codecell))
+(cl-defmethod ein:cell-insert-prompt ((cell ein:hy-codecell))
   "Insert prompt of the CELL in the buffer.
 Called from ewoc pretty printer via `ein:cell-pp'."
   ;; Newline is inserted in `ein:cell-insert-input'.
@@ -37,15 +37,15 @@ Called from ewoc pretty printer via `ein:cell-pp'."
     (when (slot-value cell 'autoexec) " %s" ein:cell-autoexec-prompt))
    'font-lock-face 'ein:cell-input-prompt))
 
-(defmethod ein:cell-execute-internal ((cell ein:hy-codecell)
-                                      kernel code &rest args)
+(cl-defmethod ein:cell-execute-internal ((cell ein:hy-codecell)
+                                         kernel code &rest args)
   (ein:cell-clear-output cell t t t)
   (ein:cell-set-input-prompt cell "*")
   (ein:cell-running-set cell t)
   (setf (slot-value cell 'dynamic) t)
   (apply #'ein:kernel-execute kernel (ein:pytools-wrap-hy-code code) (ein:cell-make-callbacks cell) args))
 
-(defmethod ein:cell-to-nb4-json :before ((cell ein:hy-codecell) _ &optional _ignore)
+(cl-defmethod ein:cell-to-nb4-json :before ((cell ein:hy-codecell) _ &optional _ignore)
   (let ((metadata (slot-value cell 'metadata)))
     (setf metadata (plist-put metadata :ein.hycell t))))
 

--- a/lisp/ein-multilang.el
+++ b/lisp/ein-multilang.el
@@ -67,7 +67,7 @@ This function may raise an error."
       ;; Emacs fontification mechanism requires the function to move
       ;; the point.  Do *not* use `(goto-char end)'.  As END is in the
       ;; input area, fontification falls into an infinite loop.
-      (ewoc-goto-node (oref cell :ewoc) (ein:cell-element-get cell :footer)))
+      (ewoc-goto-node (slot-value cell 'ewoc) (ein:cell-element-get cell :footer)))
     t))
 
 (defun ein:ml-back-to-prev-node ()

--- a/lisp/ein-notebook.el
+++ b/lisp/ein-notebook.el
@@ -721,7 +721,7 @@ This is equivalent to do ``C-c`` in the console program."
          (ws-cells (mapcar (lambda (data) (ein:cell-from-json data)) cells))
          (worksheet (ein:notebook--worksheet-new notebook)))
     (oset worksheet :saved-cells ws-cells)
-    ;(mapcar (lambda (data) (message "test %s" (oref data :metadata))) ws-cells)
+    ;(mapcar (lambda (data) (message "test %s" (slot-value data 'metadata))) ws-cells)
     (list worksheet)))
 
 (defun ein:notebook-to-json (notebook)

--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -544,9 +544,9 @@ You may find the new one in the notebook list." error)
         (widget-insert " | ")
         (widget-create
          'link
-         :notify (lambda (&rest ignore) (ein:notebooklist-open
-                                         (ein:$notebooklist-url-or-port ein:%notebooklist%)
-                                         path))
+         :notify (lambda (&rest ignore)
+                   (ein:notebooklist-login
+                    (ein:$notebooklist-url-or-port ein:%notebooklist%) path))
          name)))
     (widget-insert " |\n\n"))
 

--- a/lisp/ein-notification.el
+++ b/lisp/ein-notification.el
@@ -54,14 +54,13 @@ S-mouse-1/3 (Shift + left/right click): move this tab to left/right"
   "Help message.")
 ;; Note: can't put this below of `ein:notification-setup'...
 
-(defmethod ein:notification-status-set ((ns ein:notification-status) status)
+(cl-defmethod ein:notification-status-set ((ns ein:notification-status) status)
   (let* ((message (cdr (assoc status (slot-value ns 's2m)))))
     (setf (slot-value ns 'status) status)
     (setf (slot-value ns 'message) (substitute-command-keys message))
     (force-mode-line-update t)))
 
-(defmethod ein:notification-bind-events ((notification ein:notification)
-                                         events)
+(cl-defmethod ein:notification-bind-events ((notification ein:notification) events)
   "Bind a callback to events of the event handler EVENTS which
 just set the status (= event-type):
     (ein:notification-status-set NS EVENT-TYPE)
@@ -173,7 +172,7 @@ insert-prev insert-next move-prev move-next)"
   "Face for headline selected tab."
   :group 'ein)
 
-(defmethod ein:notification-tab-create-line ((tab ein:notification-tab))
+(cl-defmethod ein:notification-tab-create-line ((tab ein:notification-tab))
   (let ((list (funcall (slot-value tab 'get-list)))
         (current (funcall (slot-value tab 'get-current)))
         (get-name (slot-value tab 'get-name)))

--- a/lisp/ein-org.el
+++ b/lisp/ein-org.el
@@ -106,7 +106,7 @@ node `(org) External links' and Info node `(org) Search options'"
                                 :follow 'ein:org-open
                                 :help-echo "Open ipython notebook."
                                 :store 'ein:org-store-link)
-     (org-add-link-type "ipynb" :follow 'ein:org-open)
+     (org-link-set-parameters "ipynb" :follow 'ein:org-open)
      (add-hook 'org-store-link-functions 'ein:org-store-link)))
 
 ;; The above expression is evaluated via loaddef file.  At the moment,

--- a/lisp/ein-scratchsheet.el
+++ b/lisp/ein-scratchsheet.el
@@ -44,7 +44,7 @@
          :discard-output-p discard-output-p :kernel kernel :events events
          args))
 
-(defmethod ein:worksheet--buffer-name ((ws ein:scratchsheet))
+(cl-defmethod ein:worksheet--buffer-name ((ws ein:scratchsheet))
   (format ein:scratchsheet-buffer-name-template
           (ein:worksheet-url-or-port ws)
           (ein:worksheet-full-name ws)))

--- a/lisp/ein-shared-output.el
+++ b/lisp/ein-shared-output.el
@@ -96,7 +96,7 @@ Called from ewoc pretty printer via `ein:cell-pp'."
   (when (slot-value cell 'popup)
     (pop-to-buffer (ein:shared-output-create-buffer)))
   ;; Finally do the normal drawing
-  (call-next-method))
+  (cl-call-next-method))
 
 
 ;;; Main
@@ -243,7 +243,7 @@ shared output buffer.  You can open the buffer by the command
 
 (defun ein:get-kernel--shared-output ()
   (let ((cell (ein:get-cell-at-point--shared-output)))
-    (when (and (object-p cell) (slot-boundp cell :kernel))
+    (when (and (eieio-object-p cell) (slot-boundp cell :kernel))
       (slot-value cell 'kernel))))
 
 (defun ein:get-cell-at-point--shared-output ()

--- a/lisp/ein-shared-output.el
+++ b/lisp/ein-shared-output.el
@@ -58,7 +58,7 @@
 
 ;;; Cell related
 
-(defmethod ein:cell-insert-prompt ((cell ein:shared-output-cell))
+(cl-defmethod ein:cell-insert-prompt ((cell ein:shared-output-cell))
   "Insert prompt of the CELL in the buffer.
 Called from ewoc pretty printer via `ein:cell-pp'."
   ;; Newline is inserted in `ein:cell-insert-input'.
@@ -68,16 +68,16 @@ Called from ewoc pretty printer via `ein:cell-pp'."
     (when (slot-value cell 'autoexec) " %s" ein:cell-autoexec-prompt))
    'font-lock-face 'ein:cell-input-prompt))
 
-(defmethod ein:cell-execute ((cell ein:shared-output-cell) kernel code
-                             &optional popup &rest args)
+(cl-defmethod ein:cell-execute ((cell ein:shared-output-cell) kernel code
+                                &optional popup &rest args)
   (unless (plist-get args :silent)
     (setq args (plist-put args :silent nil)))
   (setf (slot-value cell 'popup) popup)
   (setf (slot-value cell 'kernel) kernel)
   (apply #'ein:cell-execute-internal cell kernel code args))
 
-(defmethod ein:cell--handle-output ((cell ein:shared-output-cell)
-                                    msg-type content _metadata-not-used-)
+(cl-defmethod ein:cell--handle-output ((cell ein:shared-output-cell)
+                                       msg-type content _metadata)
   ;; Show short message
   (ein:case-equal msg-type
     (("pyout")
@@ -165,7 +165,7 @@ Create a cell if the buffer has none."
   (ein:shared-output-get-or-create)
   (pop-to-buffer (ein:shared-output-create-buffer)))
 
-(defmethod ein:shared-output-show-code-cell ((cell ein:codecell))
+(cl-defmethod ein:shared-output-show-code-cell ((cell ein:codecell))
   "Show code CELL in shared-output buffer.
 Note that this function assumed to be called in the buffer
 where CELL locates."

--- a/lisp/ein-skewer.el
+++ b/lisp/ein-skewer.el
@@ -37,7 +37,7 @@
   (let ((val (ein:js-prepare-result
               (cdr (assoc 'value result))
               (plist-get json :output_type))))
-    (setf (oref cell :outputs) (list val))
+    (setf (slot-value cell 'outputs) (list val))
     (ein:cell-append-display-data cell val)))
 
 ;; Format of result is ((id . STR) (type . STR) (status . STR) (value . STR) (time . FLOAT))

--- a/lisp/ein-timestamp.el
+++ b/lisp/ein-timestamp.el
@@ -51,7 +51,7 @@ See `ein:format-time-string'."
   (let ((buffer-undo-list t))
     (ewoc-invalidate (ein:basecell--ewoc cell) (ein:cell-element-get cell :footer))))
 
-(defmethod ein:cell-insert-footer :after ((cell ein:codecell))
+(cl-defmethod ein:cell-insert-footer :after ((cell ein:codecell))
   (if (slot-value cell 'running)
       (ein:insert-read-only "Execution pending\n\n")
     (if-let ((etime (plist-get (ein:cell-metadata cell) :execute-time)))

--- a/lisp/ein-traceback.el
+++ b/lisp/ein-traceback.el
@@ -52,7 +52,7 @@
                  :buffer-name buffer-name
                  :source-notebook notebook))
 
-(defmethod ein:tb-get-buffer ((traceback ein:traceback))
+(cl-defmethod ein:tb-get-buffer ((traceback ein:traceback))
   (unless (and (slot-boundp traceback :buffer)
                (buffer-live-p (slot-value traceback 'buffer)))
     (let ((buf (get-buffer-create (slot-value traceback 'buffer-name))))
@@ -62,7 +62,7 @@
 (defun ein:tb-pp (ewoc-data)
   (insert (ansi-color-apply ewoc-data)))
 
-(defmethod ein:tb-render ((traceback ein:traceback) tb-data)
+(cl-defmethod ein:tb-render ((traceback ein:traceback) tb-data)
   (with-current-buffer (ein:tb-get-buffer traceback)
     (setq ein:%traceback% traceback)
     (setq buffer-read-only t)
@@ -74,7 +74,7 @@
       (mapc (lambda (data) (ewoc-enter-last ewoc data)) tb-data))
     (ein:traceback-mode)))
 
-(defmethod ein:tb-popup ((traceback ein:traceback) tb-data)
+(cl-defmethod ein:tb-popup ((traceback ein:traceback) tb-data)
   (ein:tb-render traceback tb-data)
   (pop-to-buffer (ein:tb-get-buffer traceback)))
 
@@ -95,14 +95,14 @@
         t)
     (error "No traceback is available.")))
 
-(defmethod ein:tb-range-of-node-at-point ((traceback ein:traceback))
+(cl-defmethod ein:tb-range-of-node-at-point ((traceback ein:traceback))
   (let* ((ewoc (slot-value traceback 'ewoc))
          (ewoc-node (ewoc-locate ewoc))
          (beg (ewoc-location ewoc-node))
          (end (ein:aand (ewoc-next ewoc ewoc-node) (ewoc-location it))))
     (list beg end)))
 
-(defmethod ein:tb-file-path-at-point ((traceback ein:traceback))
+(cl-defmethod ein:tb-file-path-at-point ((traceback ein:traceback))
   (destructuring-bind (beg end)
       (ein:tb-range-of-node-at-point traceback)
     (let* ((file-tail
@@ -116,7 +116,7 @@
           (concat (file-name-sans-extension file) ".py")
         file))))
 
-(defmethod ein:tb-file-lineno-at-point ((traceback ein:traceback))
+(cl-defmethod ein:tb-file-lineno-at-point ((traceback ein:traceback))
   (destructuring-bind (beg end)
       (ein:tb-range-of-node-at-point traceback)
     (when (save-excursion
@@ -124,8 +124,8 @@
             (search-forward-regexp "^[-]+> \\([0-9]+\\)" end t))
       (string-to-number (match-string 1)))))
 
-(defmethod ein:tb-jump-to-source-at-point ((traceback ein:traceback)
-                                           &optional select)
+(cl-defmethod ein:tb-jump-to-source-at-point ((traceback ein:traceback)
+                                              &optional select)
   (let ((file (ein:tb-file-path-at-point traceback))
         (lineno (ein:tb-file-lineno-at-point traceback)))
     (if (string-match "<ipython-input-\\([0-9]+\\)-.*" file)


### PR DESCRIPTION
call-next-method -> cl-call-next-method
set-slot-value -> (setf slot-value)
*-child-p -> cl-typep
oref <keyword> -> slot-value <symbol>
object-p -> eieio-object-p
Closes https://github.com/millejoh/emacs-ipython-notebook/issues/394