### PR TITLE
Avoid leaving EIN in an uninstallable state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,5 @@ before_script:
   - sh tools/install-cask.sh
 
 script:
+  - make test-install
   - make test || ( ( zip -q - log/{testein,testfunc,ecukes}.* 2>/dev/null | uuencode log.zip ) && ( printf "To diagnose, travis logs -i | dos2unix | sed '/^begin 644/,/^end/!d' | uudecode" ) && false )

--- a/lisp/ein-classes.el
+++ b/lisp/ein-classes.el
@@ -381,7 +381,7 @@ auto-execution mode flag in the connected buffer is `t'.")))
        (status_dead.Kernel . "Kernel requires restart \\[ein:notebook-restart-kernel-command]")
        (status_reconnecting.Kernel . "Kernel reconnecting...")
        (status_reconnected.Kernel . "Kernel reconnected")
-       (status_disconnected.Kernel . "Kernel requires reconnect \\[ein:notebook-reconnect-session-command]")))
+       (status_disconnected.Kernel . "Kernel requires reconnect \\[ein:notebook-reconnect-kernel]")))
     :type ein:notification-status))
   "Notification widget for Notebook.")
 

--- a/lisp/ein-classes.el
+++ b/lisp/ein-classes.el
@@ -381,7 +381,7 @@ auto-execution mode flag in the connected buffer is `t'.")))
        (status_dead.Kernel . "Kernel requires restart \\[ein:notebook-restart-kernel-command]")
        (status_reconnecting.Kernel . "Kernel reconnecting...")
        (status_reconnected.Kernel . "Kernel reconnected")
-       (status_disconnected.Kernel . "Kernel requires reconnect \\[ein:notebook-reconnect-kernel]")))
+       (status_disconnected.Kernel . "Kernel requires reconnect \\[ein:notebook-reconnect-session-command]")))
     :type ein:notification-status))
   "Notification widget for Notebook.")
 

--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -39,7 +39,6 @@
 (require 'deferred)
 (require 'dash)
 (require 'ido)
-(require 'f)
 
 (defcustom ein:notebooklist-login-timeout (truncate (* 6.3 1000))
   "Timeout in milliseconds for logging into server"
@@ -877,7 +876,7 @@ CALLBACK takes one argument, the buffer created by ein:notebooklist-open--succes
            (securep (string-match "^wss://" url-or-port)))
       (loop for (name content) on cookie-plist by (function cddr)
             for line = (mapconcat #'identity (list domain "FALSE" (car (url-path-and-query parsed-url)) (if securep "TRUE" "FALSE") "0" (symbol-name name) (concat content "\n")) "\t")
-            do (f-append-text line 'utf-8 (request--curl-cookie-jar)))))
+            do (write-region line nil (request--curl-cookie-jar) 'append))))
 
   (lexical-let* (done-p
                  (done-callback (lambda (&rest ignore) (setf done-p t)))

--- a/lisp/ein-pkg.el
+++ b/lisp/ein-pkg.el
@@ -8,6 +8,5 @@
     (request-deferred "0.2.0")
     (cl-generic "0.3")
     (dash "2.13.0")
-    (f "0.19.0")
     (s "1.11.0")
     (skewer-mode "1.6.2")))

--- a/lisp/ein-process.el
+++ b/lisp/ein-process.el
@@ -31,7 +31,6 @@
 (require 'ein-jupyter)
 (require 'ein-file)
 (require 'ein-notebooklist)
-(require 'f)
 
 (defcustom ein:process-jupyter-regexp "\\(jupyter\\|ipython\\)\\(-\\|\\s-+\\)note"
   "Regexp by which we recognize notebook servers."
@@ -141,7 +140,9 @@
   "Return the uppermost parent dir of DIR that contains ipynb files."
   (let ((fn (expand-file-name filename)))
     (loop with directory = (directory-file-name 
-                            (if (f-file? fn) (f-parent fn) fn))
+                            (if (file-regular-p fn) 
+                                (file-name-directory (directory-file-name fn)) 
+                              fn))
           with suitable = directory
           until (string= (file-name-nondirectory directory) "")
           do (if (directory-files directory nil "\\.ipynb$")


### PR DESCRIPTION
Remove `f.el` dependency introduced in 085a188.
`make test-install` to prevent leaving EIN in an uninstallable state.