### PR TITLE
C-c C-q improved visual feedback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,7 @@ autoloads:
 .PHONY: clean
 clean:
 	cask clean-elc
-
-env-ipy.%:
-	tools/makeenv.sh env/ipy.$* tools/requirement-ipy.$*.txt
+	rm -rf test/test-install
 
 .PHONY: test-compile
 test-compile: clean autoloads

--- a/features/notebooklist.feature
+++ b/features/notebooklist.feature
@@ -19,6 +19,18 @@ Scenario: Resync
   And I switch to log expr "ein:log-all-buffer-name"
   Then I should see "kernelspecs--complete"
 
+@stop
+Scenario: Stop after closing notebook
+  Given I am in notebooklist buffer
+  And I click on "New Notebook"
+  And I switch to buffer like "Untitled"
+  And I press "C-x k"
+  And I am in notebooklist buffer
+  And I keep clicking "Resync" until "Stop"
+  And I click on "Stop"
+  And I switch to log expr "ein:log-all-buffer-name"
+  Then I should see "Deleted session" 
+
 @login
 Scenario: No token server
   Given I start the server configured "c.NotebookApp.token = u''\n"

--- a/features/step-definitions/ein-steps.el
+++ b/features/step-definitions/ein-steps.el
@@ -152,6 +152,14 @@
         (ein:testing-flush-queries)
         (And "I wait 1 second"))) ;; eldoc-documentation-function not flushing
 
+(When "^I keep clicking \"\\(.+\\)\" until \"\\(.+\\)\"$"
+      (lambda (go stop)
+        (loop repeat 10
+              until (search stop (buffer-string))
+              do (And "I click on \"Resync\"")
+              do (sleep-for 0 1000)
+              finally do (if (not (search stop (buffer-string))) (assert nil)))))
+
 (When "^I click on \"\\(.+\\)\"$"
       (lambda (word)
         ;; from espuds "go to word" without the '\\b's

--- a/lisp/ein-jupyter.el
+++ b/lisp/ein-jupyter.el
@@ -200,6 +200,12 @@ the log of the running jupyter server."
           (ein:jupyter-server-login-and-open login-callback)))))
 
 ;;;###autoload
+(defalias 'ein:run 'ein:jupyter-server-start)
+
+;;;###autoload
+(defalias 'ein:stop 'ein:jupyter-server-stop)
+
+;;;###autoload
 (defun ein:jupyter-server-stop (&optional force log)
   "Stop a running jupyter notebook server.
 

--- a/lisp/ein-kernel.el
+++ b/lisp/ein-kernel.el
@@ -645,7 +645,7 @@ We need this to have proper behavior for the 'Stop' command in the ein:notebookl
   (ein:log 'info "Error, could not delete session %s." session-id))
 
 (defun ein:kernel-delete-session (kernel &optional callback)
-  "Regardless of success or error, we clear all state variables of kernel and funcall CALLBACK of arity 1, the kernel"
+  "Regardless of success or error, we clear all state variables of kernel and funcall CALLBACK (kernel)"
   (ein:and-let* ((session-id (ein:$kernel-session-id kernel)))
     (ein:query-singleton-ajax
      (list 'kernel-delete-session session-id)

--- a/lisp/ein-utils.el
+++ b/lisp/ein-utils.el
@@ -604,8 +604,15 @@ otherwise it should be a function, which is called on `time'."
 
 
 ;;; Emacs utilities
+(defmacro ein:message-whir (mesg &rest body)
+  "Display MESG with a modest animation until ASYNC-CALL completes."
+  `(lexical-let* (done-p
+                  (done-callback (lambda (&rest ignore) (setf done-p t)))
+                  (errback (lambda (&rest ignore) (setf done-p 'error))))
+     (ein:message-whir-subr ,mesg (lambda () done-p))
+     ,@body))
 
-(defun ein:message-whir (mesg doneback)
+(defun ein:message-whir-subr (mesg doneback)
   "Display MESG with a modest animation until done-p returns t.  
 
 DONEBACK returns t or 'error when calling process is done, and nil if not done."

--- a/test/test-ein-notebook.el
+++ b/test/test-ein-notebook.el
@@ -962,19 +962,10 @@ defined."
   (with-current-buffer (ein:testing-notebook-make-new)
     (let ((buffer (current-buffer))
           (notebook ein:%notebook%)
-          (kernel (ein:$notebook-kernel ein:%notebook%))
           (ein:notebook-kill-buffer-ask nil))
-      (mocker-let
-          ((ein:kernel-live-p
-            (kernel)
-            ((:input (list kernel) :output t)))
-           (ein:kernel-delete-session
-            (kernel &optional callback)
-            ((:input (list kernel (lambda (kernel) (ein:notebook-close notebook)))))))
+      (cl-letf (((symbol-function 'ein:kernel-live-p) (lambda (&rest args) t))
+                ((symbol-function 'ein:kernel-delete-session) (lambda (kernel callback) (funcall callback kernel))))
         (call-interactively #'ein:notebook-kill-kernel-then-close-command))
-      (should (buffer-live-p buffer))
-      ;; Pretend that `ein:notebook-close' is called.
-      (ein:notebook-close notebook)
       (ein:testing-notebook-should-be-closed notebook buffer))))
 
 (ert-deftest ein:notebook-kill-kernel-then-close-when-already-dead ()


### PR DESCRIPTION
Because `ein:notebook-kill-kernel-then-close-command` must wait for the
server to delete the session, the buffer wouldn't disappear right
away, leaving the user nonplussed whether the `C-c C-q` took.  Display
a status message "Ending session" with a modest animation until server replies.

Also add a test for "stopping" closed notebooks with live sessions.  Sorry about breaking this in
in ee3b0f0