### PR TITLE
use defconst to define ein:source-dir

### DIFF
--- a/lisp/ein-core.el
+++ b/lisp/ein-core.el
@@ -116,8 +116,8 @@ pair of TO-PYTHON and FROM-PYTHON."
 
 ;;; Constants
 
-(defvar ein:source-dir (file-name-directory load-file-name)
-  "Directory in which ``ein*.el`` locate.")
+(defconst ein:source-dir (file-name-directory load-file-name)
+  "Directory in which `ein*.el` files are located.")
 
 
 ;;; Configuration getter


### PR DESCRIPTION
This resets `ein:source-dir`'s value every time the file is reloaded,
which means that `ein:dev-reload` as well as elpa upgrades will reset it.