### PR TITLE
ob-ein support non-Python languages, and other minor changes

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -390,13 +390,14 @@ Org-mode integration
 --------------------
 
 You can execute org source blocks in EIN by adding `ein` to
-`org:babel-load-languages`. You need to specify a notebook via the :session
+`org:babel-load-languages`. You need to specify a notebook via the `:session`
 argument. The format for the session argument is
-`{url-or-port}/{path-to-notebook}`. For example:
+`{url-or-port}/{path-to-notebook}`. You should also specify `:results raw drawer`
+for proper rendering inside the org buffer. For example:
 
 .. code:: python
 
-   #+BEGIN_SRC ein :session 8888/Untitled.ipynb
+   #+BEGIN_SRC ein :session 8888/Untitled.ipynb :results raw drawer
    import sys
 
    a = 14500
@@ -414,7 +415,7 @@ argument as in the example below:
 
 .. code:: python
 
-   #BEGIN_SRC ein :session 8888/Untitled.ipynb :image output.png
+   #BEGIN_SRC ein :session 8888/Untitled.ipynb :results raw drawer :image output.png
    import matplotlib.pyplot as plt
    import numpy as np
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -425,6 +425,22 @@ argument as in the example below:
    plt.plot(x,y)
    #+END_SRC
 
+To get proper syntax highlighting for non-Python kernels, use the function
+:el:symbol:`ein:org-register-lang-mode` to define a new ein-based org source
+language. For example, to get proper syntax highlighting for an R kernel, first call
+
+.. sourcecode:: cl
+
+    (ein:org-register-lang-mode "ein-R" 'R)
+
+Then org SRC blocks with language "ein-R" will use R syntax highlighting:
+
+.. code:: python
+
+   #BEGIN_SRC ein-R :session 8888/Untitled.ipynb :results raw drawer :image output.png
+   plot(1:10, 1:10)
+   #+END_SRC
+
 You can also link to an IPython notebook from org-mode_ files.
 
 1. Call org-mode function :el:symbol:`org-store-link`
@@ -448,6 +464,7 @@ Customization
 
 .. el:variable:: ein:org-async-p
 .. el:variable:: ein:org-inline-image-directory
+.. el:function:: ein:org-register-lang-mode
 
 Support for The Hy Language (EXPERIMENTAL)
 ------------------------------------------

--- a/lisp/ein-cell.el
+++ b/lisp/ein-cell.el
@@ -959,6 +959,12 @@ Note that ``html`` comes before ``text``."
   :type '(choice function (repeat symbol))
   :group 'ein)
 
+(defvar ein:output-types-text-preferred
+  '(emacs-lisp svg image/svg png image/png jpeg image/jpeg text text/plain html text/html latex text/latex javascript text/javascript))
+
+(defvar ein:output-types-html-preferred
+  '(emacs-lisp svg image/svg png image/png jpeg image/jpeg html text/html latex text/latex javascript text/javascript text text/plain))
+
 (defun ein:output-type-prefer-pretty-text-over-html (data)
   "Use text type if it is a \"prettified\" text instead of HTML.
 This is mostly for *not* using HTML table for pandas but using
@@ -967,8 +973,8 @@ HTML for other object.
 If the text type output contains a newline, it is assumed be a
 prettified text thus be used instead of HTML type."
   (if (ein:aand (plist-get data :text) (string-match-p "\n" it))
-      '(emacs-lisp svg image/svg png image/png jpeg image/jpeg text text/plain html text/html latex text/latex javascript text/javascript)
-    '(emacs-lisp svg image/svg png image/png jpeg image/jpeg html text/html latex text/latex javascript text/javascript text text/plain)))
+      ein:output-types-text-preferred
+    ein:output-types-html-preferred))
 
 (defun ein:fix-mime-type (type)
   (ein:aif (assoc type ein:mime-type-map)

--- a/lisp/ob-ein.el
+++ b/lisp/ob-ein.el
@@ -56,6 +56,18 @@
 (add-to-list 'org-src-lang-modes '("ein" . python))
 (add-to-list 'org-src-lang-modes '("ein-hy" . hy))
 
+;; based on ob-ipython--configure-kernel
+(defun ein:org-register-lang-mode (lang-name lang-mode)
+  "Define org+ein language LANG-NAME with syntax highlighting from LANG-MODE.
+For example, call (ein:org-register-lang-mode \"ein-R\" 'R) to define a language \"ein-R\" with R syntax highlighting for use with org-babel and ein."
+  (add-to-list 'org-src-lang-modes `(,lang-name . ,lang-mode))
+  (defvaralias (intern (concat "org-babel-default-header-args:" lang-name))
+    'org-babel-default-header-args:ein)
+  (defalias (intern (concat "org-babel-execute:" lang-name))
+    'org-babel-execute:ein)
+  (defalias (intern (concat "org-babel-" lang-name "-initiate-session"))
+    'org-babel-ein-initiate-session))
+
 ;; Handling source block execution results
 (defun ein:temp-inline-image-info (value)
   (let* ((f (md5 value))

--- a/lisp/ob-ein.el
+++ b/lisp/ob-ein.el
@@ -88,10 +88,7 @@ For example, call (ein:org-register-lang-mode \"ein-R\" 'R) to define a language
 
 (defun ein:return-mime-type (json file)
   (loop
-   for key in (cond
-               ((functionp ein:output-type-preference)
-                (funcall ein:output-type-preference json))
-               (t ein:output-type-preference))
+   for key in ein:output-types-text-preferred
    for type = (intern (format ":%s" key)) ; something like `:text'
    for value = (plist-get json type)      ; FIXME: optimize
    when (plist-member json type)


### PR DESCRIPTION
This is a PR implementing the feature I requested in #405 yesterday.

It adds a function `ein:org-register-lang-mode` that registers a new org-babel SRC block type, that uses ob-ein on the backend, but arbitrary language-mode for syntax highlighting. For example, calling `(ein:org-register-lang-mode "ein-R" 'R)` in your config file will allow for proper R syntax highlighting in the following org-mode SRC block:
```
#+BEGIN_SRC ein-R :session 8888/Untitled.ipynb
    plot(1:10, 1:10)
#+END_SRC
```

In addition, I changed the output processing to always prefer text over html output, as org-mode does not properly render html output. This was an issue with R kernels that will return html output when returning lists, for example.

Finally, I changed the docs to recommend using `:results raw drawer` for all SRC blocks (this is also recommended in ob-ipython). `:results raw` is needed to properly plot images from R (otherwise the image link simply gets printed into an example block with no rendering). `:results drawer` fixes problems with multiline output not being properly replaced when re-executing a SRC block -- I noticed this happening with both R and Python.