### PR TITLE
notebook-mode as a proper minor mode

### DIFF
--- a/lisp/ein-company.el
+++ b/lisp/ein-company.el
@@ -90,7 +90,7 @@
   (interactive (list 'interactive))
   (cl-case command
     (interactive (company-begin-backend 'ein:company-backend) )
-    (prefix (and (--filter (and (boundp it) (symbol-value it) (or (eql it 'ein:notebook-minor-mode)
+    (prefix (and (--filter (and (boundp it) (symbol-value it) (or (eql it 'ein:notebook-mode)
                                                                   (eql it 'ein:connect-mode)))
                            minor-mode-list)
                  (ein:object-at-point)))

--- a/lisp/ein-pager.el
+++ b/lisp/ein-pager.el
@@ -30,8 +30,11 @@
 (require 'ein-core)
 (require 'ein-events)
 (require 'view)
+(require 'ess-help nil t)
 
 ;; FIXME: Make a class with `:get-notebook-name' slot like `ein:worksheet'
+
+(declare-function ess-help-underline "ess-help")
 
 (defun ein:pager-new (name events)
   ;; currently pager = name.
@@ -63,6 +66,8 @@
 (defun ein:pager-append-text (pager text)
   (ein:with-read-only-buffer (get-buffer-create pager)
     (insert (ansi-color-apply text))
+    (if (featurep 'ess-help)
+        (ess-help-underline))
     (unless (eql 'ein:pager-mode major-mode)
       (ein:pager-mode))))
 


### PR DESCRIPTION
Previously `notebook-mode` was an ordinary function that called
`notebook-minor-mode` to install `ein:notebook-mode-map`.  We make
`ein:notebook-mode` a proper minor mode via `define-minor-mode`.  This
has a few visible benefits primarily that `describe-mode` or `f1 m` will now
show all the keybindings, and mode-line will reflect.

As a consequence `ein:notebook-mode-hook` is no longer an explicit
`defcustom` (proper minor modes get it for free).  This had been a
dangerous situation as the default hook containing critical functions could be overridden.