### PR TITLE
[WIP] Respect cursor_start and cursor_end in company

### DIFF
--- a/lisp/ein-company.el
+++ b/lisp/ein-company.el
@@ -91,11 +91,8 @@
 (defun ein:company-backend (command &optional arg &rest _)
   (interactive (list 'interactive))
   (cl-case command
-    (interactive (company-begin-backend 'ein:company-backend) )
-    (prefix (and (--filter (and (boundp it) (symbol-value it) (or (eql it 'ein:notebook-mode)
-                                                                  (eql it 'ein:connect-mode)))
-                           minor-mode-list)
-                 (ein:object-at-point)))
+    (interactive (company-begin-backend 'ein:company-backend))
+    (prefix (and (eq major-mode 'ein:notebook-multilang-mode) (ein:object-at-point)))
     (annotation (let ((kernel (ein:get-kernel)))
                   (ein:aif (gethash arg (ein:$kernel-oinfo-cache kernel))
                            (plist-get it :definition))))
@@ -142,7 +139,6 @@
                                               (list :object object
                                                     :callback cb)))))
 
-(setq ein:complete-on-dot nil)
 (when (boundp 'company-backends)
   (add-to-list 'company-backends 'ein:company-backend))
 

--- a/lisp/ein-company.el
+++ b/lisp/ein-company.el
@@ -42,50 +42,55 @@
 (defun ein:company--deferred-complete ()
   (let ((d (deferred:new #'identity))
         (kernel (ein:get-kernel)))
-    (if (ein:kernel-live-p kernel)
-        (ein:completer-complete
-         kernel
-         :callbacks
-         (list :complete_reply
-               (cons (lambda (d &rest args) (deferred:callback-post d args))
-                     d)))
-      ;; Pass "no match" result when kernel the request was not sent:
-      (deferred:callback-post d (list nil nil)))
+    (ein:completer-complete
+     kernel
+     :callbacks
+     (list :complete_reply
+           (cons (lambda (d* &rest args) (deferred:callback-post d* args))
+                 d))
+     :errback
+     (apply-partially (lambda (d* err) (deferred:callback-post d* err)) d))
     d))
 
-(defun ein:company--complete (fetcher-callback)
+(defun ein:company--complete (prefix fetcher)
   (deferred:$
     (deferred:next
       (lambda ()
         (ein:company--deferred-complete)))
     (deferred:nextc it
       (lambda (replies)
-        (ein:completions--prepare-matches fetcher-callback replies)))))
+        (unless (stringp replies) ;; if not an error
+          (ein:completions--prepare-matches prefix fetcher replies))))))
 
-(defun ein:company--complete-jedi (fetcher-callback)
+(defun ein:company--complete-jedi (fetcher)
   (deferred:$
     (deferred:parallel
       (jedi:complete-request)
      (ein:company--deferred-complete))
     (deferred:nextc it
       (lambda (replies)
-        (ein:completions--prepare-matches-jedi fetcher-callback replies)))))
+        (ein:completions--prepare-matches-jedi fetcher replies)))))
 
 (defun ein:completions--prepare-matches-jedi (cb replies)
   (destructuring-bind
       (_ ((&key matches &allow-other-keys) ; :complete_reply
-          _))
+          _metadata))
       replies
     (ein:completions--build-oinfo-cache matches)
     (funcall cb matches)))
 
-(defun ein:completions--prepare-matches (cb replies)
+(defun ein:completions--prepare-matches (prefix fetcher replies)
   (destructuring-bind
-      ((&key _matched_text matches &allow-other-keys) ; :complete_reply
-       _)
+      ((&key matches cursor_start cursor_end &allow-other-keys) ; :complete_reply
+       _metadata)
       replies
     (ein:completions--build-oinfo-cache matches)
-    (funcall cb matches)))
+    (let ((nix (- cursor_end cursor_start))
+          insertable-matches)
+      (dolist (match matches)
+        (setq insertable-matches 
+              (nconc insertable-matches (list (concat prefix (substring match nix))))))
+      (funcall fetcher insertable-matches))))
 
 ;;;###autoload
 (defun ein:company-backend (command &optional arg &rest _)
@@ -96,32 +101,29 @@
     (annotation (let ((kernel (ein:get-kernel)))
                   (ein:aif (gethash arg (ein:$kernel-oinfo-cache kernel))
                            (plist-get it :definition))))
-    (doc-buffer (lexical-let ((arg arg))
-                  (cons :async
-                        (lambda (cb)
-                          (ein:company-handle-doc-buffer arg cb)))))
-    (location (lexical-let ((obj arg))
-                (cons :async
+    (doc-buffer (cons :async
                       (lambda (cb)
-                        (ein:pytools-find-source (ein:get-kernel-or-error)
-                                                 obj
-                                                 cb)))))
-    (candidates (or
-                 (ein:completions--find-cached-completion (ein:object-at-point)
-                                                          (ein:$kernel-oinfo-cache (ein:get-kernel-or-error)))
-                 (lexical-let ((kernel (ein:get-kernel-or-error))
-                               (col (current-column)))
-                   (unless (ein:company-backend--punctuation-check (thing-at-point 'line) col)
-                     (case ein:completion-backend
-                       (ein:use-company-jedi-backend
-                        (cons :async (lambda (cb)
-                                       (ein:company--complete-jedi cb))))
-                       (t
-                        (cons :async
-                              (lambda (cb)
-                                (ein:company--complete cb)))))))))))
+                        (ein:company-handle-doc-buffer arg cb))))
+    (location (cons :async
+                    (lambda (cb)
+                      (ein:pytools-find-source (ein:get-kernel-or-error)
+                                               arg
+                                               cb))))
+    (candidates 
+     (let* ((kernel (ein:get-kernel-or-error))
+            (cached (ein:completions-get-cached arg (ein:$kernel-oinfo-cache kernel))))
+       (ein:aif cached it
+         (unless (ein:company--punctuation-check (thing-at-point 'line) (current-column))
+           (case ein:completion-backend
+             (ein:use-company-jedi-backend
+              (cons :async (lambda (cb)
+                             (ein:company--complete-jedi cb))))
+             (t
+              (cons :async
+                    (lambda (cb)
+                      (ein:company--complete arg cb)))))))))))
 
-(defun ein:company-backend--punctuation-check (thing col)
+(defun ein:company--punctuation-check (thing col)
   (let ((query (ein:trim-right (subseq thing 0 col) "[\n]")))
     (string-match "[]()\",[{}'=: ]$" query (- col 2))))
 

--- a/lisp/ein-completer.el
+++ b/lisp/ein-completer.el
@@ -37,6 +37,8 @@
 (require 'ein-pytools)
 (require 'dash)
 
+(make-obsolete-variable 'ein:complete-on-dot nil "0.15.0")
+
 (defun ein:completer-choose ()
   (cond
    ((and (or (eq ein:completion-backend 'ein:use-ac-backend)
@@ -109,22 +111,6 @@
                  ((not (ac-cursor-on-diable-face-p)))
                  ((ein:kernel-live-p kernel)))
     (ein:completer-complete kernel :expand nil)))
-
-(defcustom ein:complete-on-dot t
-  "Start completion when inserting a dot.  Note that
-`ein:use-auto-complete-superpack' must be `t' to enable this option.
-This variable has effect on notebook buffers and connected buffers."
-  :type 'boolean
-  :group 'ein-completion)
-
-(defun ein:complete-on-dot-install (map &optional func)
-  (if (and ein:complete-on-dot
-           (featurep 'auto-complete)
-           (or (eql ein:completion-backend 'ein:use-ac-backend)
-               (eql ein:completion-backend 'ein:use-ac-jedi-backend)))
-      (define-key map "." (or func #'ein:completer-dot-complete))
-    (define-key map "." nil)))
-
 
 ;;; Retrieving Python Object Info
 (defun ein:completions--reset-oinfo-cache (kernel)

--- a/lisp/ein-connect.el
+++ b/lisp/ein-connect.el
@@ -397,11 +397,11 @@ notebook."
   (case ein:completion-backend
     (ein:use-ac-backend
      (assert (featurep 'ein-ac))
-     (ein:complete-on-dot-install ein:connect-mode-map)
+     (define-key ein:connect-mode-map "." #'ein:completer-dot-complete)
      (auto-complete-mode))
     (ein:use-ac-jedi-backend
      (assert (featurep 'ein-ac))
-     (ein:jedi-complete-on-dot-install ein:connect-mode-map)
+     (define-key ein:connect-mode-map "." #'ein:completer-dot-complete)
      (auto-complete-mode))
     (ein:use-company-backend
      (assert (featurep 'ein-company))

--- a/lisp/ein-jedi.el
+++ b/lisp/ein-jedi.el
@@ -84,9 +84,6 @@
   (unless (ac-cursor-on-diable-face-p)
     (ein:jedi-complete :expand nil)))
 
-(defun ein:jedi-complete-on-dot-install (map)
-  (ein:complete-on-dot-install map #'ein:jedi-dot-complete))
-
 ;;;###autoload
 (defun ein:jedi-setup ()
   "Setup auto-completion using EIN and Jedi.el_ together.
@@ -98,8 +95,7 @@ To use EIN and Jedi together, add the following in your Emacs setup before loadi
 
 .. _Jedi.el: https://github.com/tkf/emacs-jedi"
   (let ((map ein:connect-mode-map))
-    (define-key map "\C-c\C-i" 'ein:jedi-complete)
-    (ein:jedi-complete-on-dot-install map)))
+    (define-key map "\C-c\C-i" 'ein:jedi-complete)))
 
 (provide 'ein-jedi)
 

--- a/lisp/ein-kernel.el
+++ b/lisp/ein-kernel.el
@@ -458,7 +458,7 @@ Sample implementations
             (ein:$kernel-after-execute-hook kernel)))
     msg-id))
 
-(defun ein:kernel-complete (kernel line cursor-pos callbacks)
+(defun ein:kernel-complete (kernel line cursor-pos callbacks errback)
   "Complete code at CURSOR-POS in a string LINE on KERNEL.
 
 CURSOR-POS is the position in the string LINE, not in the buffer.
@@ -469,27 +469,30 @@ When calling this method pass a CALLBACKS structure of the form:
 
 Call signature::
 
-  (`funcall' FUNCTION ARGUMENT CONTENT METADATA)
+  (funcall FUNCTION ARGUMENT CONTENT METADATA)
 
 CONTENT and METADATA are given by `complete_reply' message.
 
 `complete_reply' message is documented here:
 http://ipython.org/ipython-doc/dev/development/messaging.html#complete
 "
-  (assert (ein:kernel-live-p kernel) nil "complete_reply: Kernel is not active.")
-  (let* ((content (if (< (ein:$kernel-api-version kernel) 5)
-                      (list
-                       ;; :text ""
-                       :line line
-                       :cursor_pos cursor-pos)
-                    (list
-                     :code line
-                     :cursor_pos cursor-pos)))
-         (msg (ein:kernel--get-msg kernel "complete_request" content))
-         (msg-id (plist-get (plist-get msg :header) :msg_id)))
-    (ein:websocket-send-shell-channel kernel msg)
-    (ein:kernel-set-callbacks-for-msg kernel msg-id callbacks)
-    msg-id))
+  (condition-case err
+      (let* ((content (if (< (ein:$kernel-api-version kernel) 5)
+                          (list
+                           ;; :text ""
+                           :line line
+                           :cursor_pos cursor-pos)
+                        (list
+                         :code line
+                         :cursor_pos cursor-pos)))
+             (msg (ein:kernel--get-msg kernel "complete_request" content))
+             (msg-id (plist-get (plist-get msg :header) :msg_id)))
+        (assert (ein:kernel-live-p kernel) nil "complete_reply: Kernel is not active.")
+        (ein:websocket-send-shell-channel kernel msg)
+        (ein:kernel-set-callbacks-for-msg kernel msg-id callbacks)
+        msg-id)
+    (error (if errback (funcall errback (error-message-string err))
+             (ein:display-warning (error-message-string err) :error)))))
 
 
 (defun* ein:kernel-history-request (kernel callbacks

--- a/lisp/ein-notebook.el
+++ b/lisp/ein-notebook.el
@@ -582,11 +582,9 @@ notebook buffer then the user will be prompted to select an opened notebook."
 (defun ein:notebook-complete-dot ()
   "Insert dot and request completion."
   (interactive)
-  (unless (or (eql ein:completion-backend 'ein:use-company-backend)
-              (eql ein:completion-backend 'ein:use-company-jedi-backend))
-    (if (and ein:%notebook% (ein:codecell-p (ein:get-cell-at-point)))
-        (ein:completer-dot-complete)
-      (insert "."))))
+  (if (and ein:%notebook% (ein:codecell-p (ein:get-cell-at-point)))
+      (ein:completer-dot-complete)
+    (insert ".")))
 
 (defun ein:notebook-kernel-interrupt-command ()
   "Interrupt the kernel.
@@ -1565,11 +1563,11 @@ appropriate function as the buffer-local value of `eldoc-documentation-function'
     (case ein:completion-backend
       (ein:use-ac-backend
        (assert (featurep 'ein-ac))
-       (ein:complete-on-dot-install ein:notebook-mode-map 'ein:notebook-complete-dot)
+       (define-key ein:notebook-mode-map "." #'ein:notebook-complete-dot)
        (auto-complete-mode))
       (ein:use-ac-jedi-backend
        (assert (featurep 'ein-ac))
-       (ein:jedi-complete-on-dot-install ein:notebook-mode-map)
+       (define-key ein:notebook-mode-map "." #'ein:notebook-complete-dot)
        (auto-complete-mode))
       (ein:use-company-backend
        (assert (featurep 'ein-company))


### PR DESCRIPTION
With respect to `ein-company`,
Py2 kernels prepend prefixes to completions, e.g., np.array.
Py3 kernels do not, e.g., array.
The `:cursor_start` and `:cursor_end` fields from ipykernel's `complete_reply` tell us whether we need to
prepend the prefix ourselves.

Fixes #436