### PR TITLE
ein-completer: Hotifx for completion in IPython 7.2

### DIFF
--- a/lisp/ein-company.el
+++ b/lisp/ein-company.el
@@ -36,6 +36,7 @@
 
 (autoload 'company-begin-backend "company")
 (autoload 'company-doc-buffer "company")
+(autoload 'company-prefix "company")
 
 ;; Duplicates ein:jedi--completer-complete in ein-jedi.
 ;; Let's refactor and enhance our calm!

--- a/lisp/ein-company.el
+++ b/lisp/ein-company.el
@@ -76,7 +76,7 @@
       (_ ((&key matches &allow-other-keys) ; :complete_reply
           _))
       replies
-    (ein:completions--build-oinfo-cache matches)
+    (ein:completions--build-oinfo-cache matches company-prefix)
     (funcall cb matches)))
 
 (defun ein:completions--prepare-matches (cb replies)
@@ -84,7 +84,7 @@
       ((&key _matched_text matches &allow-other-keys) ; :complete_reply
        _)
       replies
-    (ein:completions--build-oinfo-cache matches)
+    (ein:completions--build-oinfo-cache matches company-prefix)
     (funcall cb matches)))
 
 ;;;###autoload

--- a/lisp/ein-company.el
+++ b/lisp/ein-company.el
@@ -36,7 +36,7 @@
 
 (autoload 'company-begin-backend "company")
 (autoload 'company-doc-buffer "company")
-(autoload 'company-prefix "company")
+(defvar-local company-prefix nil) ;; Just like in company.el
 
 ;; Duplicates ein:jedi--completer-complete in ein-jedi.
 ;; Let's refactor and enhance our calm!

--- a/lisp/ein-completer.el
+++ b/lisp/ein-completer.el
@@ -150,6 +150,8 @@ This variable has effect on notebook buffers and connected buffers."
 (defun ein:completions--build-oinfo-cache (objs)
   (let ((kernel (ein:get-kernel)))
     (dolist (o (-non-nil objs))
+      (when (not (string-prefix-p company-prefix o))
+        (setq o (concatenate 'string company-prefix o)))
       (deferred:$
         (deferred:next
           (lambda ()

--- a/lisp/ein-completer.el
+++ b/lisp/ein-completer.el
@@ -147,11 +147,11 @@ This variable has effect on notebook buffers and connected buffers."
       (deferred:callback-post d (list nil nil)))
     d))
 
-(defun ein:completions--build-oinfo-cache (objs)
+(defun ein:completions--build-oinfo-cache (objs &optional prefix)
   (let ((kernel (ein:get-kernel)))
     (dolist (o (-non-nil objs))
-      (when (not (string-prefix-p company-prefix o))
-        (setq o (concatenate 'string company-prefix o)))
+      (when (and prefix (not (string-prefix-p prefix o)))
+        (setq o (concatenate 'string prefix o)))
       (deferred:$
         (deferred:next
           (lambda ()


### PR DESCRIPTION
Quick fix to work around IPython 7.2's new penchant for ~not~ including the prefix in matches returned in complete_reply messages.

@dickmao - I know you had a number of useful changes in #441  that cleaned up the company backend code, but if you want you can look at this PR for a very, very simple change that gets back completion in the company backend under IPython 7.2.