### PR TITLE
Respect cursor_start and cursor_end in matches

### DIFF
--- a/Cask
+++ b/Cask
@@ -17,5 +17,7 @@
  (depends-on "skewer-mode")
  (depends-on "deferred")
  (depends-on "auto-complete")
+ (depends-on "company")
+ (depends-on "smartrep")
  (depends-on "f")
  (depends-on "s"))

--- a/features/notebook.feature
+++ b/features/notebook.feature
@@ -44,7 +44,7 @@ Scenario: company completion
   And I press "M-RET"
   And I type "itertools."
   And I call "company-complete"
-  And I wait for completions "itertools.accumulate"
+  And I wait for completions "itertools.chain"
   And I press "C-a"
   And I press "C-k"
   And I clear websocket log

--- a/features/notebook.feature
+++ b/features/notebook.feature
@@ -35,6 +35,30 @@ Scenario: no auto completion
   And I wait for the smoke to clear
   Then "ein:ac-direct-matches" should not include "itertools"
 
+@complete
+Scenario: company completion
+  Given I set "ein:completion-backend" to eval "(quote ein:use-company-backend)"
+  Given I kill all websocket buffers
+  Given new default notebook
+  And I type "import itertools"
+  And I press "M-RET"
+  And I type "itertools."
+  And I call "company-complete"
+  And I wait for completions "itertools.accumulate"
+  And I press "C-a"
+  And I press "C-k"
+  And I clear websocket log
+  And I type "itertool"
+  And I call "company-complete"
+  Then I should see "itertools"
+  And I type ".chai"
+  And I call "company-complete"
+  Then I should see "itertools.chain"
+  Then no completion traffic
+  Given I set "ein:completion-backend" to eval "(quote ein:use-ac-backend)"
+  Given new default notebook
+  Given I set "ein:completion-backend" to eval "(quote ein:use-none-backend)"
+
 @switch
 Scenario: switch kernel
   Given new default notebook

--- a/lisp/ein-connect.el
+++ b/lisp/ein-connect.el
@@ -379,6 +379,7 @@ notebook."
   (define-key map "\M-,"          'ein:pytools-jump-back-command)
   (define-key map (kbd "C-c C-,") 'ein:pytools-jump-back-command)
   (define-key map (kbd "C-c C-/") 'ein:notebook-scratchsheet-open)
+
   map)
 
 (defun ein:connect-mode-get-lighter ()
@@ -396,18 +397,14 @@ notebook."
   :group 'ein
   (case ein:completion-backend
     (ein:use-ac-backend
-     (assert (featurep 'ein-ac))
-     (ein:complete-on-dot-install ein:connect-mode-map)
+     (define-key ein:connect-mode-map "." 'ein:ac-dot-complete)
      (auto-complete-mode))
     (ein:use-ac-jedi-backend
-     (assert (featurep 'ein-ac))
-     (ein:jedi-complete-on-dot-install ein:connect-mode-map)
+     (define-key ein:connect-mode-map "." 'ein:ac-dot-complete)
      (auto-complete-mode))
     (ein:use-company-backend
-     (assert (featurep 'ein-company))
      (company-mode))
     (ein:use-company-jedi-backend
-     (assert (featurep 'ein-company))
      (company-mode))))
 
 (put 'ein:connect-mode 'permanent-local t)

--- a/lisp/ein-contents-api.el
+++ b/lisp/ein-contents-api.el
@@ -68,7 +68,7 @@ global setting.  For global setting and more information, see
   (apply #'ein:content-url* (ein:$content-url-or-port content) (ein:$content-path content) params))
 
 (defun ein:content-url* (url-or-port path &rest params)
-  (let* ((which (if (<= (ein:need-notebook-version url-or-port) 2)
+  (let* ((which (if (< (ein:notebook-version-numeric url-or-port) 3)
                     "notebooks" "contents"))
          (api-path (concat "api/" which)))
     (url-encode-url (apply #'ein:url
@@ -116,7 +116,7 @@ global setting.  For global setting and more information, see
                                                          &key data symbol-status response
                                                          &allow-other-keys)
   (let (content)
-    (if (<= (ein:need-notebook-version url-or-port) 2)
+    (if (< (ein:notebook-version-numeric url-or-port) 3)
         (setq content (ein:new-content-legacy url-or-port path data))
       (setq content (ein:new-content url-or-port path data)))
     (ein:aif response
@@ -173,7 +173,7 @@ global setting.  For global setting and more information, see
       (ein:new-content url-or-port path data)
     (let ((content (make-ein:$content
                     :url-or-port url-or-port
-                    :notebook-version (ein:need-notebook-version url-or-port)
+                    :notebook-version (ein:notebook-version-numeric url-or-port)
                     :path path)))
       (setf (ein:$content-name content) (substring path (or (cl-position ?/ path) 0))
             (ein:$content-path content) path
@@ -190,7 +190,7 @@ global setting.  For global setting and more information, see
   ;; data is like (:size 72 :content nil :writable t :path Untitled7.ipynb :name Untitled7.ipynb :type notebook)
   (let ((content (make-ein:$content
                   :url-or-port url-or-port
-                  :notebook-version (ein:need-notebook-version url-or-port)
+                  :notebook-version (ein:notebook-version-numeric url-or-port)
                   :path path)))
     (setf (ein:$content-name content) (plist-get data :name)
           (ein:$content-path content) (plist-get data :path)
@@ -377,7 +377,7 @@ global setting.  For global setting and more information, see
 
 (defun* ein:content-query-sessions--success (url-or-port callback &key data &allow-other-keys)
   (cl-flet ((read-name (nb-json)
-                       (if (= (ein:need-notebook-version url-or-port) 2)
+                       (if (< (ein:notebook-version-numeric url-or-port) 3)
                            (if (string= (plist-get nb-json :path) "")
                                (plist-get nb-json :name)
                              (format "%s/%s" (plist-get nb-json :path) (plist-get nb-json :name)))

--- a/lisp/ein-core.el
+++ b/lisp/ein-core.el
@@ -206,18 +206,14 @@ the source is in git repository) or elpa version."
                                                      &aux (resp-string (format "STATUS: %s DATA: %s" (request-response-status-code response) data)))
   (ein:log 'debug "ein:query-kernelspecs--complete %s" resp-string))
 
-(defsubst ein:get-ipython-major-version (vstr)
-  (if vstr
-      (string-to-number (car (split-string vstr "\\.")))
-    (if (>= ein:log-level (ein:log-level-name-to-int 'debug))
-        (throw 'error "Null value passed to ein:get-ipython-major-version.")
-      (ein:log 'warn "Null value passed to ein:get-ipython-major-version."))))
+(defsubst ein:notebook-version-numeric (url-or-port)
+  (truncate (string-to-number (ein:need-notebook-version url-or-port))))
 
 (defun ein:need-notebook-version (url-or-port)
   "Callers assume ein:query-notebook-version succeeded.  If not, we hardcode a guess."
   (ein:aif (gethash url-or-port *ein:notebook-version*) it
     (ein:log 'warn "No recorded notebook version for %s" url-or-port)
-    5))
+    "5.7.0"))
 
 (defun ein:query-notebook-version (url-or-port callback)
   "Send for notebook version of URL-OR-PORT with CALLBACK arity 0 (just a semaphore)"
@@ -234,11 +230,10 @@ the source is in git repository) or elpa version."
                                              &aux (resp-string (format "STATUS: %s DATA: %s" (request-response-status-code response) data)))
   (ein:log 'debug "ein:query-notebook-version--complete %s" resp-string)
   (ein:aif (plist-get data :version)
-      (setf (gethash url-or-port *ein:notebook-version*)
-            (ein:get-ipython-major-version it))
+      (setf (gethash url-or-port *ein:notebook-version*) it)
     (case (request-response-status-code response)
       (404 (ein:log 'warn "notebook version api not implemented")
-           (setf (gethash url-or-port *ein:notebook-version*) 2))
+           (setf (gethash url-or-port *ein:notebook-version*) "2.0.0"))
       (t (ein:log 'warn "notebook version currently unknowable"))))
   (when callback (funcall callback)))
 

--- a/lisp/ein-events.el
+++ b/lisp/ein-events.el
@@ -52,7 +52,7 @@ When EVENT-TYPE is triggered on the event handler EVENTS,
 CALLBACK is called.  CALLBACK must take two arguments:
 ARG as the first argument and DATA, which is passed via
 `ein:events-trigger', as the second."
-  (assert (symbolp event-type))
+  (assert (symbolp event-type) t "%s not symbol" event-type)
   (let* ((table (slot-value events 'callbacks))
          (cbs (gethash event-type table)))
     (push (cons callback arg) cbs)

--- a/lisp/ein-kernel.el
+++ b/lisp/ein-kernel.el
@@ -97,7 +97,6 @@
             :date (format-time-string "%Y-%m-%dT%T" (current-time)) ; ISO 8601 timestamp
             :msg_type msg-type)
    :metadata (make-hash-table)
-
    :content content
    :parent_header (make-hash-table)))
 
@@ -458,10 +457,12 @@ Sample implementations
             (ein:$kernel-after-execute-hook kernel)))
     msg-id))
 
-(defun ein:kernel-complete (kernel line cursor-pos callbacks)
+(defun ein:kernel-complete (kernel line cursor-pos callbacks errback)
   "Complete code at CURSOR-POS in a string LINE on KERNEL.
 
 CURSOR-POS is the position in the string LINE, not in the buffer.
+
+ERRBACK takes a string (error message).
 
 When calling this method pass a CALLBACKS structure of the form:
 
@@ -469,27 +470,30 @@ When calling this method pass a CALLBACKS structure of the form:
 
 Call signature::
 
-  (`funcall' FUNCTION ARGUMENT CONTENT METADATA)
+  (funcall FUNCTION ARGUMENT CONTENT METADATA)
 
 CONTENT and METADATA are given by `complete_reply' message.
 
 `complete_reply' message is documented here:
 http://ipython.org/ipython-doc/dev/development/messaging.html#complete
 "
-  (assert (ein:kernel-live-p kernel) nil "complete_reply: Kernel is not active.")
-  (let* ((content (if (< (ein:$kernel-api-version kernel) 5)
-                      (list
-                       ;; :text ""
-                       :line line
-                       :cursor_pos cursor-pos)
-                    (list
-                     :code line
-                     :cursor_pos cursor-pos)))
-         (msg (ein:kernel--get-msg kernel "complete_request" content))
-         (msg-id (plist-get (plist-get msg :header) :msg_id)))
-    (ein:websocket-send-shell-channel kernel msg)
-    (ein:kernel-set-callbacks-for-msg kernel msg-id callbacks)
-    msg-id))
+  (condition-case err
+      (let* ((content (if (< (ein:$kernel-api-version kernel) 5)
+                          (list
+                           ;; :text ""
+                           :line line
+                           :cursor_pos cursor-pos)
+                        (list
+                         :code line
+                         :cursor_pos cursor-pos)))
+             (msg (ein:kernel--get-msg kernel "complete_request" content))
+             (msg-id (plist-get (plist-get msg :header) :msg_id)))
+        (assert (ein:kernel-live-p kernel) nil "kernel not live")
+        (ein:websocket-send-shell-channel kernel msg)
+        (ein:kernel-set-callbacks-for-msg kernel msg-id callbacks)
+        msg-id)
+    (error (if errback (funcall errback (error-message-string err))
+             (ein:display-warning (error-message-string err) :error)))))
 
 
 (defun* ein:kernel-history-request (kernel callbacks

--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -414,7 +414,7 @@ This function is called via `ein:notebook-after-rename-hook'."
                                                 &allow-other-keys)
   (let ((nbname (plist-get data :name))
         (nbpath (plist-get data :path)))
-    (when (= (ein:need-notebook-version url-or-port) 2)
+    (when (< (ein:notebook-version-numeric url-or-port) 3)
       (if (string= nbpath "")
           (setq nbpath nbname)
         (setq nbpath (format "%s/%s" nbpath nbname))))
@@ -572,7 +572,7 @@ You may find the new one in the notebook list." error)
   "Render the header (for ipython>=3)."
   (with-current-buffer (ein:notebooklist-get-buffer url-or-port)
     (widget-insert
-     (format "Notebook v%s (%s)\n\n" (ein:$notebooklist-api-version ein:%notebooklist%) url-or-port))
+     (format "Contents API %s (%s)\n\n" (ein:need-notebook-version url-or-port) url-or-port))
 
     (let ((breadcrumbs (generate-breadcrumbs (ein:$notebooklist-path ein:%notebooklist%))))
       (dolist (p breadcrumbs)
@@ -694,7 +694,7 @@ You may find the new one in the notebook list." error)
                      "Dir")
                     (widget-insert " : " name)
                     (widget-insert "\n"))
-          if (and (string= type "file") (> (ein:need-notebook-version url-or-port) 2))
+          if (and (string= type "file") (> (ein:notebook-version-numeric url-or-port) 2))
           do (progn (widget-create
                      'link
                      :notify (lexical-let ((url-or-port url-or-port)

--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -35,6 +35,8 @@
 (require 'ein-file)
 (require 'ein-contents-api)
 (require 'ein-subpackages)
+(require 'ein-ac)
+(require 'ein-company)
 (require 'deferred)
 (require 'dash)
 (require 'ido)
@@ -165,7 +167,6 @@ This function adds NBLIST to `ein:notebooklist-map'."
     (ein:notebooklist-list-remove url-or-port)))
 
 (defun ein:notebooklist-get-buffer (url-or-port)
-  (assert url-or-port)
   (get-buffer-create
    (format ein:notebooklist-buffer-name-template url-or-port)))
 
@@ -242,7 +243,6 @@ TODO: going to maintain jupyterhub hooks here
 "
   (unless path (setq path ""))
   (setq url-or-port (ein:url url-or-port)) ;; should work towards not needing this
-  (ein:subpackages-load)
   (lexical-let* ((url-or-port url-or-port)
                  (path path)
                  (success (apply-partially #'ein:notebooklist-open--finish
@@ -457,11 +457,10 @@ You may find the new one in the notebook list." error)
      path
      (apply-partially
       (lambda (name* notebook created)
-        (assert created)
+        (unless created
+          (ein:log 'warn "Notebook %s already existed" name))
         (with-current-buffer (ein:notebook-buffer notebook)
           (ein:notebook-rename-command name*)
-          ;; As `ein:notebook-open' does not call `pop-to-buffer' when
-          ;; callback is specified, `pop-to-buffer' must be called here:
           (pop-to-buffer (current-buffer))))
       name))))
 

--- a/lisp/ein-smartrep.el
+++ b/lisp/ein-smartrep.el
@@ -25,7 +25,7 @@
 
 ;;; Code:
 
-(require 'smartrep)
+(require 'smartrep nil t)
 
 (defcustom ein:smartrep-notebook-mode-alist
   '(("C-t" . ein:worksheet-toggle-cell-type)

--- a/lisp/ein-smartrep.el
+++ b/lisp/ein-smartrep.el
@@ -25,9 +25,7 @@
 
 ;;; Code:
 
-(require 'ein-notebook)
-
-(declare-function smartrep-define-key "smartrep")
+(require 'smartrep)
 
 (defcustom ein:smartrep-notebook-mode-alist
   '(("C-t" . ein:worksheet-toggle-cell-type)
@@ -45,10 +43,10 @@
   :type '(repeat (cons string function))
   :group 'ein)
 
-(defun ein:smartrep-config ()
-  (smartrep-define-key
-      ein:notebook-mode-map
-      "C-c"
+(defmacro ein:smartrep-config (map)
+  `(smartrep-define-key
+    ,map
+    "C-c"
     ein:smartrep-notebook-mode-alist))
 
 (provide 'ein-smartrep)

--- a/lisp/ein-subpackages.el
+++ b/lisp/ein-subpackages.el
@@ -20,12 +20,12 @@
 ;; along with ein-subpackages.el.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
+;; This module was more important when packages came from git submodules.
+;; It has been gutted since.
 
 ;;
 
 ;;; Code:
-
-(declare-function ein:smartrep-config "ein-smartrep")
 
 (defcustom ein:completion-backend 'ein:use-ac-backend
   "Determines which completion backend to use in opened EIN notebooks.
@@ -46,34 +46,6 @@ you restart Emacs. The available completion backends are::
           (const ein:use-company-jedi-backend)
           (const ein:use-none-backend))
   :group 'ein-completion)
-
-(defcustom ein:use-smartrep nil
-  "Set to `t' to use preset smartrep configuration.
-
-.. warning:: When used with MuMaMo (see `ein:notebook-modes'),
-   keyboard macro which manipulates cell (add, remove, move,
-   etc.) may start infinite loop (you need to stop it with
-   ``C-g``).  Please be careful using this option if you are a
-   heavy keyboard macro user.  Using keyboard macro for other
-   commands is fine.
-
-.. (Comment) I guess this infinite loop happens because the three
-   modules (kmacro.el, mumamo.el and smartrep.el) touches to
-   `unread-command-events' in somehow inconsistent ways."
-  :type 'boolean
-  :group 'ein)
-
-(defun ein:subpackages-load ()
-  "Load sub-packages depending on configurations."
-  (cl-case ein:completion-backend
-    (ein:use-ac-backend (require 'ein-ac))
-    (ein:use-ac-jedi-backend (require 'ein-ac))
-    (ein:use-company-backend (require 'ein-company))
-    (ein:use-company-jedi-backend (require 'ein-company)))
-  (when ein:use-smartrep
-    (with-eval-after-load "ein-smartrep"
-      (ein:smartrep-config))
-    (require 'ein-smartrep)))
 
 (provide 'ein-subpackages)
 

--- a/lisp/ein-worksheet.el
+++ b/lisp/ein-worksheet.el
@@ -192,7 +192,9 @@
             (setq ein:%which-cell%
                   (nconc (make-list fill (car ein:%which-cell%))
                          ein:%which-cell%))))))
-  (cl-assert (= (length buffer-undo-list) (length ein:%which-cell%))))
+  (cl-assert (= (length buffer-undo-list) (length ein:%which-cell%)) t
+             "ein:worksheet--jigger-undo-list %d != %d"
+             (length buffer-undo-list) (length ein:%which-cell%)))
 
 (defun ein:worksheet--unshift-undo-list (cell &optional exogenous-input old-cell)
   "Adjust `buffer-undo-list' for adding CELL.  Unshift in list parlance means prepending to list."
@@ -232,7 +234,9 @@
                     (ein:log 'debug "unsh adj %s %s" u cell-id)
                     (setq lst (nconc lst (list (funcall func-after-cell u)))))
                 (setq lst (nconc lst (list u)))))))
-        (cl-assert (= (length buffer-undo-list) (length lst)))
+        (cl-assert (= (length buffer-undo-list) (length lst)) t
+                   "ein:worksheet--unshift-undo-list %d != %d"
+                   (length buffer-undo-list) (length lst))
         (setq buffer-undo-list lst)
         (ein:worksheet--update-cell-lengths cell exogenous-input)))))
 
@@ -418,7 +422,6 @@
     (set-buffer-modified-p nil)
     (ein:worksheet-bind-events ws)
     (ein:worksheet-set-kernel ws)
-    (ein:gc-complete-operation)
     (ein:log 'info "Worksheet %s is ready" (ein:worksheet-full-name ws))))
 
 (defun ein:worksheet-pp (ewoc-data)

--- a/test/ein-testing-notebook.el
+++ b/test/ein-testing-notebook.el
@@ -39,9 +39,9 @@
          (path (plist-get data :path))
          (kernelspec (make-ein:$kernelspec :name "python" :language "python"))
          (content (make-ein:$content :url-or-port ein:testing-notebook-dummy-url
-                                     :notebook-version 4
+                                     :notebook-version "5.7.0"
                                      :path path)))
-    (cl-letf (((symbol-function 'ein:need-notebook-version) (lambda (&rest ignore) 4))
+    (cl-letf (((symbol-function 'ein:need-notebook-version) (lambda (&rest ignore) "5.7.0"))
               ((symbol-function 'ein:kernel-retrieve-session) #'ignore)
               ((symbol-function 'ein:notebook-enable-autosaves) #'ignore))
       (let ((notebook (ein:notebook-new ein:testing-notebook-dummy-url path kernelspec)))

--- a/test/ein-testing.el
+++ b/test/ein-testing.el
@@ -100,7 +100,7 @@ if I call this between links in a deferred chain.  Adding a flush-queue."
           (ein:notebooklist-new-notebook url-or-port ks nil
                                          (lambda (nb created &rest ignore)
                                            (setq notebook nb)))
-          (ein:testing-wait-until (lambda () 
+          (ein:testing-wait-until (lambda ()
                                     (and notebook
                                          (ein:aand (ein:$notebook-kernel notebook)
                                                    (ein:kernel-live-p it))))

--- a/test/test-ein-notebooklist.el
+++ b/test/test-ein-notebooklist.el
@@ -7,7 +7,7 @@
             ((symbol-function 'ein:content-query-sessions) #'ignore))
     (ein:notebooklist-open--finish (or url-or-port ein:testing-notebook-dummy-url) nil 
      (make-ein:$content :url-or-port (or url-or-port ein:testing-notebook-dummy-url)
-                        :notebook-version 3
+                        :notebook-version "5.7.0"
                         :path ""))))
 
 (defmacro eintest:notebooklist-is-empty-context-of (func)


### PR DESCRIPTION
The :cursor_start and :cursor_end fields tell us whether we need to
prepend the prefix ourselves.

Fixes #436
