### PR TITLE
Ignore nonascii completion

### DIFF
--- a/lisp/ein-company.el
+++ b/lisp/ein-company.el
@@ -97,7 +97,7 @@
     (prefix (and (eq major-mode 'ein:notebook-multilang-mode) (ein:object-at-point)))
     (annotation (let ((kernel (ein:get-kernel)))
                   (ein:aif (gethash arg (ein:$kernel-oinfo-cache kernel))
-                           (plist-get it :definition))))
+                      (plist-get it :definition))))
     (doc-buffer (cons :async
                       (lambda (cb)
                         (ein:company-handle-doc-buffer arg cb))))
@@ -110,7 +110,7 @@
      (let* ((kernel (ein:get-kernel-or-error))
             (cached (ein:completions-get-cached arg (ein:$kernel-oinfo-cache kernel))))
        (ein:aif cached it
-         (unless (ein:company--punctuation-check (thing-at-point 'line) (current-column))
+         (unless (and (looking-at "[[:nonascii:]]") (ein:company--punctuation-check (thing-at-point 'line) (current-column)))
            (case ein:completion-backend
              (ein:use-company-jedi-backend
               (cons :async (lambda (cb)


### PR DESCRIPTION
Comment in Non-English will cause company error.

```emacs-lisp
Debugger entered--Lisp error: (args-out-of-range #("# 测试\n" 0 1 (fontified t font-lock-face font-lock-comment-delimiter-face font-lock-fontified t font-lock-multiline t) 1 4 (fontified t font-lock-face font-lock-comment-delimiter-face font-lock-fontified t font-lock-multiline t) 4 5 (fontified t font-lock-face font-lock-comment-face font-lock-fontified t font-lock-multiline t)) 0 6)
  subseq(#("# 测试\n" 0 1 (fontified t font-lock-face font-lock-comment-delimiter-face font-lock-fontified t font-lock-multiline t) 1 4 (fontified t font-lock-face font-lock-comment-delimiter-face font-lock-fontified t font-lock-multiline t) 4 5 (fontified t font-lock-face font-lock-comment-face font-lock-fontified t font-lock-multiline t)) 0 6)
  (ein:trim-right (subseq thing 0 col) "[\n]")
  (let ((query (ein:trim-right (subseq thing 0 col) "[\n]"))) (string-match "[]()\",[{}'=: ]$" query (- col 2)))
  ein:company--punctuation-check(#("# 测试\n" 0 1 (fontified t font-lock-face font-lock-comment-delimiter-face font-lock-fontified t font-lock-multiline t) 1 4 (fontified t font-lock-face font-lock-comment-delimiter-face font-lock-fontified t font-lock-multiline t) 4 5 (fontified t font-lock-face font-lock-comment-face font-lock-fontified t font-lock-multiline t)) 6)
  (if (ein:company--punctuation-check (thing-at-point 'line) (current-column)) nil (cond ((eql ein:completion-backend 'ein:use-company-jedi-backend) (cons :async (function (lambda (cb) (ein:company--complete-jedi cb))))) (t (cons :async (function (lambda (cb) (ein:company--complete arg cb)))))))
  (if it it (if (ein:company--punctuation-check (thing-at-point 'line) (current-column)) nil (cond ((eql ein:completion-backend 'ein:use-company-jedi-backend) (cons :async (function (lambda (cb) (ein:company--complete-jedi cb))))) (t (cons :async (function (lambda (cb) (ein:company--complete arg cb))))))))
  (let ((it cached)) (if it it (if (ein:company--punctuation-check (thing-at-point 'line) (current-column)) nil (cond ((eql ein:completion-backend 'ein:use-company-jedi-backend) (cons :async (function (lambda (cb) (ein:company--complete-jedi cb))))) (t (cons :async (function (lambda (cb) (ein:company--complete arg cb)))))))))
  (let* ((kernel (ein:get-kernel-or-error)) (cached (ein:completions-get-cached arg (progn (or (and (memq (type-of kernel) cl-struct-ein:$kernel-tags) t) (signal 'wrong-type-argument (list 'ein:$kernel kernel))) (aref kernel 17))))) (let ((it cached)) (if it it (if (ein:company--punctuation-check (thing-at-point 'line) (current-column)) nil (cond ((eql ein:completion-backend 'ein:use-company-jedi-backend) (cons :async (function (lambda (cb) (ein:company--complete-jedi cb))))) (t (cons :async (function (lambda (cb) (ein:company--complete arg cb))))))))))
  (cond ((eql command 'interactive) (company-begin-backend 'ein:company-backend)) ((eql command 'prefix) (and (eq major-mode 'ein:notebook-multilang-mode) (ein:object-at-point))) ((eql command 'annotation) (let ((kernel (ein:get-kernel))) (let ((it (gethash arg (progn (or (and (memq (type-of kernel) cl-struct-ein:$kernel-tags) t) (signal 'wrong-type-argument (list 'ein:$kernel kernel))) (aref kernel 17))))) (if it (plist-get it :definition))))) ((eql command 'doc-buffer) (cons :async (function (lambda (cb) (ein:company-handle-doc-buffer arg cb))))) ((eql command 'location) (cons :async (function (lambda (cb) (ein:pytools-find-source (ein:get-kernel-or-error) arg cb))))) ((eql command 'candidates) (let* ((kernel (ein:get-kernel-or-error)) (cached (ein:completions-get-cached arg (progn (or (and (memq (type-of kernel) cl-struct-ein:$kernel-tags) t) (signal 'wrong-type-argument (list 'ein:$kernel kernel))) (aref kernel 17))))) (let ((it cached)) (if it it (if (ein:company--punctuation-check (thing-at-point 'line) (current-column)) nil (cond ((eql ein:completion-backend 'ein:use-company-jedi-backend) (cons :async (function (lambda (cb) (ein:company--complete-jedi cb))))) (t (cons :async (function (lambda (cb) (ein:company--complete arg cb))))))))))))
  ein:company-backend(candidates #("测试" 0 2 (fontified t font-lock-face font-lock-comment-delimiter-face font-lock-fontified t font-lock-multiline t)))
  apply(ein:company-backend (candidates #("测试" 0 2 (fontified t font-lock-face font-lock-comment-delimiter-face font-lock-fontified t font-lock-multiline t))))
  company-call-backend-raw(candidates #("测试" 0 2 (fontified t font-lock-face font-lock-comment-delimiter-face font-lock-fontified t font-lock-multiline t)))
  company--fetch-candidates(#("测试" 0 2 (fontified t font-lock-face font-lock-comment-delimiter-face font-lock-fontified t font-lock-multiline t)))
  company-calculate-candidates(#("测试" 0 2 (fontified t font-lock-face font-lock-comment-delimiter-face font-lock-fontified t font-lock-multiline t)) nil)
  company--begin-new()
  company--perform()
  company-auto-begin()
  company-idle-begin(#<buffer *ein: http://127.0.0.1:8888/Exercise.ipynb*> #<window 455 on *ein: http://127.0.0.1:8888/Exercise.ipynb*> 1224636 207)
  apply(company-idle-begin (#<buffer *ein: http://127.0.0.1:8888/Exercise.ipynb*> #<window 455 on *ein: http://127.0.0.1:8888/Exercise.ipynb*> 1224636 207))
  timer-event-handler([t 23637 40502 312630 nil company-idle-begin (#<buffer *ein: http://127.0.0.1:8888/Exercise.ipynb*> #<window 455 on *ein: http://127.0.0.1:8888/Exercise.ipynb*> 1224636 207) nil 0])
```
 
This pull request ignores completion when Non-English chars exist at cursor.