### PR TITLE
Toggle output (C-c C-e) should also invalidate footer

### DIFF
--- a/features/undo.feature
+++ b/features/undo.feature
@@ -44,7 +44,7 @@ Scenario: Collapse doesn't break undo
   And I press "C-<up>"
   And I press "C-c C-e"
   And I press "C-/"
-  Then the cursor should be at point "76"
+  Then the cursor should be at point "77"
   And I undo again
   Then the cursor should be at point "55"
 

--- a/lisp/ein-cell.el
+++ b/lisp/ein-cell.el
@@ -675,7 +675,8 @@ Return language name as a string or `nil' when not defined.
     (setf (slot-value cell 'collapsed) collapsed)
     (apply #'ewoc-invalidate
            (slot-value cell 'ewoc)
-           (ein:cell-element-get cell :output))))
+           (append (ein:cell-element-get cell :output)
+                   (list (ein:cell-element-get cell :footer))))))
 
 (cl-defmethod ein:cell-collapse ((cell ein:codecell))
   (ein:cell-set-collapsed cell t))


### PR DESCRIPTION
Avoid leaving a peachpuff or pink newline when toggling output with nonempty stderr.