### PR TITLE
text/plain over text/html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ _static
 .gitattributes
 .ecukes-temp*
 dist
+*.ob-ein.ipynb

--- a/lisp/ein-cell.el
+++ b/lisp/ein-cell.el
@@ -976,7 +976,9 @@ HTML for other object.
 
 If the text type output contains a newline, it is assumed be a
 prettified text thus be used instead of HTML type."
-  (if (ein:aand (plist-get data :text) (string-match-p "\n" it))
+  (if (ein:aand (or (plist-get data :text)
+                    (plist-get data :text/plain))
+                (string-match-p "\n" it))
       ein:output-types-text-preferred
     ein:output-types-html-preferred))
 


### PR DESCRIPTION
Notebooks with :text/plain and :text/html outputs opt for
:text/html which looks bad in emacs.

There is already code to prefer :text over :text/html, so it should
prefer :text/plain as well.