### PR TITLE
spacemacs guards

### DIFF
--- a/README.in.rst
+++ b/README.in.rst
@@ -25,7 +25,7 @@ EIN was originally written by tkf_.  More `complete documentation`_ is available
 
 Install
 =======
-Install from MELPA_ (recommended) or ``make install`` from github source.  You will need to install Cask_ for the latter.
+Install from MELPA_ (recommended) or ``make install`` from github source.
 
 Usage
 =====
@@ -50,9 +50,11 @@ Open an ``.ipynb`` file normally in emacs and press ``C-c C-o``.
 
 It doesn't work
 ---------------
-As an emacs user, you are likely accustomed to self-diagnose.
+EIN is tested and developed on GNU Emacs.  Your mileage may vary with the `spacemacs layer`_ and other *emacsen*.
 
-First issue ``M-x ein:dev-start-debug``.  Then reproduce the error.
+You may also try to self-diagnose:
+
+First invoke ``M-x ein:dev-start-debug``.  Then reproduce the error.
 
 Higher level diagnostics appear in ``M-x ein:log-pop-to-all-buffer``.
 
@@ -66,9 +68,10 @@ Highlighted Features
 * Easily copy cells between different notebooks.
 * Execute code from an arbitrary buffer in a running kernel.  See `Keybindings - Connect`_.
 * Jump to definition via ``M-.``
-* Completion via auto-complete_ or company-mode_.
+* Completion via company-mode_.
 * Limited jupyterhub_ support.
 
+.. _spacemacs layer: https://github.com/syl20bnr/spacemacs/tree/master/layers/%2Blang/ipython-notebook
 .. _auto-complete: https://github.com/auto-complete/auto-complete
 .. _company-mode: https://github.com/company-mode/company-mode
 .. _jupyterhub: https://github.com/jupyterhub/jupyterhub

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ EIN was originally written by tkf_.  More `complete documentation`_ is available
 
 Install
 =======
-Install from MELPA_ (recommended) or ``make install`` from github source.  You will need to install Cask_ for the latter.
+Install from MELPA_ (recommended) or ``make install`` from github source.
 
 Usage
 =====
@@ -50,9 +50,11 @@ Open an ``.ipynb`` file normally in emacs and press ``C-c C-o``.
 
 It doesn't work
 ---------------
-As an emacs user, you are likely accustomed to self-diagnose.
+EIN is tested and developed on GNU Emacs.  Your mileage may vary with the `spacemacs layer`_ and other *emacsen*.
 
-First issue ``M-x ein:dev-start-debug``.  Then reproduce the error.
+You may also try to self-diagnose:
+
+First invoke ``M-x ein:dev-start-debug``.  Then reproduce the error.
 
 Higher level diagnostics appear in ``M-x ein:log-pop-to-all-buffer``.
 
@@ -66,9 +68,10 @@ Highlighted Features
 * Easily copy cells between different notebooks.
 * Execute code from an arbitrary buffer in a running kernel.  See `Keybindings - Connect`_.
 * Jump to definition via ``M-.``
-* Completion via auto-complete_ or company-mode_.
+* Completion via company-mode_.
 * Limited jupyterhub_ support.
 
+.. _spacemacs layer: https://github.com/syl20bnr/spacemacs/tree/master/layers/%2Blang/ipython-notebook
 .. _auto-complete: https://github.com/auto-complete/auto-complete
 .. _company-mode: https://github.com/company-mode/company-mode
 .. _jupyterhub: https://github.com/jupyterhub/jupyterhub

--- a/lisp/ein-dev.el
+++ b/lisp/ein-dev.el
@@ -228,6 +228,7 @@ callback (`websocket-callback-debug-on-error') is enabled."
    ;; http://coderepos.org/share/browser/lang/elisp/init-loader/init-loader.el
    :emacs-variant
    (cond ((featurep 'meadow) 'meadow)
+         ((featurep 'core-spacemacs) 'spacemacs)
          ((featurep 'carbon-emacs-package) 'carbon))
    :os (list
         :uname (ein:dev-stdout-program "uname" '("-a"))

--- a/lisp/ein-notebook.el
+++ b/lisp/ein-notebook.el
@@ -825,7 +825,8 @@ This is equivalent to do ``C-c`` in the console program."
             (get-buffer buf))))
   (condition-case err
       (with-current-buffer (ein:notebook-buffer notebook)
-        (run-hooks 'before-save-hook))
+        (cl-letf (((symbol-function 'delete-trailing-whitespace) #'ignore))
+          (run-hooks 'before-save-hook)))
     (error (ein:log 'warn "ein:notebook-save-notebook: Saving despite '%s'."
                     (error-message-string err))))
   (let ((content (ein:content-from-notebook notebook)))
@@ -1752,6 +1753,9 @@ Called via `kill-emacs-query-functions'."
                    (ein:log 'info "Killing all notebook buffers... Done!"))
           (ein:log 'info "Canceled to kill all notebooks."))
       (ein:log 'info "No opened notebooks."))))
+
+(if (boundp 'undo-tree-incompatible-major-modes)
+      (nconc undo-tree-incompatible-major-modes (list (ein:notebook-choose-mode))))
 
 (provide 'ein-notebook)
 


### PR DESCRIPTION
Give spacemacs users undo capability even though it's untested.
Head off `delete-trailing-whitespace` error imposed by `dotspacemacs-whitespace-cleanup`.

cc #489 #445 #338