### PR TITLE
indent name tag

### DIFF
--- a/lisp/ob-ein.el
+++ b/lisp/ob-ein.el
@@ -102,8 +102,9 @@
       (let ((el (org-element-context))
             (id (org-id-new 'none)))
         (goto-char (org-element-property :begin el))
-        (indent-according-to-mode)
-        (insert (format "#+NAME: %s\n" id))
+        (back-to-indentation)
+        (split-line)
+        (insert (format "#+NAME: %s" id))
         id))))
 
 (defun ein:org-register-lang-mode (lang-name lang-mode)

--- a/lisp/ob-ein.el
+++ b/lisp/ob-ein.el
@@ -102,6 +102,7 @@
       (let ((el (org-element-context))
             (id (org-id-new 'none)))
         (goto-char (org-element-property :begin el))
+        (indent-according-to-mode)
         (insert (format "#+NAME: %s\n" id))
         id))))
 


### PR DESCRIPTION
So that it's aligned with the indentation of the source block

before
```
* test 
#+NAME: 21b06eb9-1125-4f8f-8a2c-1e352459e92f
  #+BEGIN_SRC ein :session localhost
    print("hello")
  #+END_SRC

  #+RESULTS: 21b06eb9-1125-4f8f-8a2c-1e352459e92f
  : hello
```

after

```
* test 
  #+NAME: 21b06eb9-1125-4f8f-8a2c-1e352459e92f
  #+BEGIN_SRC ein :session localhost
    print("hello")
  #+END_SRC

  #+RESULTS: 21b06eb9-1125-4f8f-8a2c-1e352459e92f
  : hello
```