### PR TITLE
Undo did not account for slideshow

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,6 @@ Keymap (C-h m)
    C-c C-a		ein:worksheet-insert-cell-above
    C-c C-b		ein:worksheet-insert-cell-below
    C-c C-c		ein:worksheet-execute-cell
-   C-c C-d		ein:worksheet-toggle-slide-type
    C-c C-e		ein:worksheet-toggle-output
    C-c C-f		ein:file-open
    C-c C-h		ein:pytools-request-tooltip-or-help
@@ -168,7 +167,7 @@ Keymap (C-h m)
    C-c 7		ein:notebook-worksheet-open-7th
    C-c 8		ein:notebook-worksheet-open-8th
    C-c 9		ein:notebook-worksheet-open-last
-   C-c S		ein:worksheet-toggle-slideshow-view
+   C-c S		ein:worksheet-toggle-slide-type
    C-c i		ein:inspect-object
    C-c {		ein:notebook-worksheet-open-prev-or-last
    C-c }		ein:notebook-worksheet-open-next-or-first

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -529,7 +529,6 @@ Notebook
 .. el:variable:: ein:helm-kernel-history-search-auto-pattern
 .. el:variable:: ein:output-type-preference
 .. el:variable:: ein:shr-env
-.. el:variable:: ein:worksheet-show-slide-data
 .. el:variable:: ein:notebook-autosave-frequency
 .. el:variable:: ein:notebook-create-checkpoint-on-save
 

--- a/lisp/ein-cell.el
+++ b/lisp/ein-cell.el
@@ -474,8 +474,8 @@ Return language name as a string or `nil' when not defined.
     (footer (ein:cell-insert-footer data))))
 
 (defun ein:maybe-show-slideshow-data (cell)
-  (when (ein:worksheet--show-slide-data-p ein:%worksheet%)
-    (format " - Slide [%s]:" (or (ein:oref-safe cell 'slidetype)  " "))))
+  (unless (equal (slot-value cell 'slidetype) "-")
+    (format " - Slide [%s]:" (slot-value cell 'slidetype))))
 
 (cl-defmethod ein:cell-insert-prompt ((cell ein:codecell))
   "Insert prompt of the CELL in the buffer.

--- a/lisp/ein-classes.el
+++ b/lisp/ein-classes.el
@@ -198,9 +198,6 @@
    (kernel :initarg :kernel :type ein:$kernel :accessor ein:worksheet--kernel)
    (dirty :initarg :dirty :type boolean :initform nil :accessor ein:worksheet--dirty-p)
    (metadata :initarg :metadata :initform nil :accessor ein:worksheet--metadata)
-   (show-slide-data-p :initarg :show-slide-data-p
-                      :initform nil
-                      :accessor ein:worksheet--show-slide-data-p)
    (events :initarg :events :accessor ein:worksheet--events)))
 
 

--- a/lisp/ein-notebook.el
+++ b/lisp/ein-notebook.el
@@ -668,24 +668,23 @@ This is equivalent to do ``C-c`` in the console program."
 
 (defun ein:notebook--worksheet-render (notebook ws)
   (ein:worksheet-render ws)
-  (save-current-buffer
-    (with-current-buffer (ein:worksheet-buffer ws)
-      (if ein:polymode
-          (poly-ein-mode)
-        ;; Changing major mode here is super dangerous as it
-        ;; kill-all-local-variables.
-        ;; Our saviour has been `ein:deflocal' which applies 'permanent-local
-        ;; to variables assigned up to this point, but we ought not rely on it
-        (funcall (ein:notebook-choose-mode))
-        (ein:worksheet-reinstall-undo-hooks ws)
-        (ein:aif (ein:$notebook-kernelspec notebook)
-            (ein:ml-lang-setup it)))
-      (ein:notebook-mode)
-      (ein:notebook--notification-setup notebook)
-      (ein:notebook-setup-kill-buffer-hook)
-      (setq ein:%notebook% notebook)
-      (when ein:polymode
-        (poly-ein-fontify-buffer notebook)))))
+  (with-current-buffer (ein:worksheet-buffer ws)
+    (if ein:polymode
+        (poly-ein-mode)
+      ;; Changing major mode here is super dangerous as it
+      ;; kill-all-local-variables.
+      ;; Our saviour has been `ein:deflocal' which applies 'permanent-local
+      ;; to variables assigned up to this point, but we ought not rely on it
+      (funcall (ein:notebook-choose-mode))
+      (ein:worksheet-reinstall-undo-hooks ws)
+      (ein:aif (ein:$notebook-kernelspec notebook)
+          (ein:ml-lang-setup it)))
+    (ein:notebook-mode)
+    (ein:notebook--notification-setup notebook)
+    (ein:notebook-setup-kill-buffer-hook)
+    (setq ein:%notebook% notebook)
+    (when ein:polymode
+      (poly-ein-fontify-buffer notebook))))
 
 (defun ein:notebook--notification-setup (notebook)
   (ein:notification-setup
@@ -1406,7 +1405,6 @@ Use simple `python-mode' based notebook mode when MuMaMo is not installed::
 (let ((map ein:notebook-mode-map))
   (ein:notebook--define-key map "\C-ci" 'ein:inspect-object)
   (ein:notebook--define-key map "\C-c'" 'ein:edit-cell-contents)
-  (ein:notebook--define-key map "\C-cS" 'ein:worksheet-toggle-slideshow-view)
   (ein:notebook--define-key map "\C-c\C-c" 'ein:worksheet-execute-cell)
   (ein:notebook--define-key map (kbd "M-RET") 'ein:worksheet-execute-cell-and-goto-next)
   (ein:notebook--define-key map (kbd "<M-S-return>")
@@ -1424,7 +1422,7 @@ Use simple `python-mode' based notebook mode when MuMaMo is not installed::
   (ein:notebook--define-key map "\C-c\C-a" 'ein:worksheet-insert-cell-above)
   (ein:notebook--define-key map "\C-c\C-b" 'ein:worksheet-insert-cell-below)
   (ein:notebook--define-key map "\C-c\C-t" 'ein:worksheet-toggle-cell-type)
-  (ein:notebook--define-key map "\C-c\C-d" 'ein:worksheet-toggle-slide-type)
+  (ein:notebook--define-key map "\C-cS" 'ein:worksheet-toggle-slide-type)
   (ein:notebook--define-key map "\C-c\C-u" 'ein:worksheet-change-cell-type)
   (ein:notebook--define-key map "\C-c\C-s" 'ein:worksheet-split-cell-at-point)
   (ein:notebook--define-key map "\C-c\C-m" 'ein:worksheet-merge-cell)
@@ -1558,8 +1556,7 @@ Use simple `python-mode' based notebook mode when MuMaMo is not installed::
             ("Interrupt kernel" ein:notebook-kernel-interrupt-command))))
       ("Worksheets [Experimental]"
        ,@(ein:generate-menu
-          '(("Toggle slide metadata view" ein:worksheet-toggle-slideshow-view)
-            ("Rename worksheet" ein:worksheet-rename-sheet)
+          '(("Rename worksheet" ein:worksheet-rename-sheet)
             ("Insert next worksheet"
              ein:notebook-worksheet-insert-next)
             ("Insert previous worksheet"


### PR DESCRIPTION
C-c C-d breaks undo.  Fix as follows:

Before: turn on slide indicator via C-c S, toggle type with C-c C-d

After: toggle type with C-c S.

Benefits: Fixes undo, simplifies slideshow operation, elpy users are
accustomed to having C-c C-d be "jump to doc"