### PR TITLE
Test emacs 25.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
       env: EVM_EMACS=emacs-26.1-travis IPYTHON=7.4.0
     - os: osx
       language: generic
-      env: EVM_EMACS=emacs-25.1 IPYTHON=5.8.0 TOXENV=py27
+      env: EVM_EMACS=emacs-25.2 IPYTHON=5.8.0 TOXENV=py27
 
   allow_failures:
     - env: EVM_EMACS=emacs-snapshot

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
   include:
     - os: linux
       python: 2.7
-      env: EVM_EMACS=emacs-25.2-travis IPYTHON=5.8.0
+      env: EVM_EMACS=emacs-25.1-travis IPYTHON=5.8.0
     - os: linux
       python: 3.5
       env: EVM_EMACS=emacs-26.1-travis IPYTHON=6.5.0
@@ -37,7 +37,7 @@ matrix:
       env: EVM_EMACS=emacs-26.1-travis IPYTHON=7.4.0
     - os: osx
       language: generic
-      env: EVM_EMACS=emacs-25.2 IPYTHON=5.8.0 TOXENV=py27
+      env: EVM_EMACS=emacs-25.1 IPYTHON=5.8.0 TOXENV=py27
 
   allow_failures:
     - env: EVM_EMACS=emacs-snapshot

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ It doesn't work
 ---------------
 
 EIN is tested on GNU Emacs versions
-25.2
+25.1
 and later. Your mileage may vary with the `spacemacs layer`_ and other *emacsen*.
 
 You may also try to self-diagnose:


### PR DESCRIPTION
Well, ubuntu 16.04 LTS does top out at emacs 25.1.1.  We probably should be testing this version.

cc #508