### PR TITLE
Gate the add-functions in ein:polymode

### DIFF
--- a/test/test-poly.el
+++ b/test/test-poly.el
@@ -1,1 +1,2 @@
-(setq ein:polymode t)
+(custom-set-variables
+  '(ein:polymode t))


### PR DESCRIPTION
Following the suggestion of Gastove in #537, only adulterate important syntax-ppss and jit-lock functions when user enables `ein:polymode`.

This should in theory prevent contamination reported in #537 among users who do not enable `ein:polymode`.  Enablers of `ein:polymode` should in theory remain susceptible to contamination.