### PR TITLE
Normalize the kernelspec language string.

### DIFF
--- a/lisp/ein-core.el
+++ b/lisp/ein-core.el
@@ -178,6 +178,12 @@ the source is in git repository) or elpa version."
    :success (apply-partially #'ein:query-kernelspecs--success url-or-port callback)
    :error (apply-partially #'ein:query-kernelspecs--error url-or-port callback iteration)))
 
+(defun ein:normalize-kernelspec-language (name)
+  "Normalize the kernelspec language string"
+  (if (stringp name)
+      (replace-regexp-in-string "[ ]" "-" (downcase name))
+    name))
+
 (defun* ein:query-kernelspecs--success (url-or-port callback
                                        &key data symbol-status response
                                        &allow-other-keys)
@@ -191,8 +197,9 @@ the source is in git repository) or elpa version."
                                                                   :display-name (plist-get (plist-get info :spec)
                                                                                            :display_name)
                                                                   :resources (plist-get info :resources)
-                                                                  :language (plist-get (plist-get info :spec)
-                                                                                       :language)
+                                                                  :language (ein:normalize-kernelspec-language
+                                                                             (plist-get (plist-get info :spec)
+                                                                                        :language))
                                                                   :spec (plist-get info :spec)))
                                  ks))))))
   (when callback (funcall callback)))

--- a/lisp/ein-core.el
+++ b/lisp/ein-core.el
@@ -181,7 +181,7 @@ the source is in git repository) or elpa version."
 (defun ein:normalize-kernelspec-language (name)
   "Normalize the kernelspec language string"
   (if (stringp name)
-      (replace-regexp-in-string "[ ]" "-" (downcase name))
+      (replace-regexp-in-string "[ ]" "-" name)
     name))
 
 (defun* ein:query-kernelspecs--success (url-or-port callback


### PR DESCRIPTION
Some jupyter kernels specify as `language` in the file `kernel.json` a string with spaces and with some letters capitalized. One example is the [WolframLanguageForJupyter](https://github.com/WolframResearch/WolframLanguageForJupyter) kernel which specifies "Wolfram Language".

EIN uses this string to construct some function names. For example in the file `ein-multilang.el` the function `ein:ml-lang-setup` uses it as follows:
```
(setup-func (intern (concat "ein:ml-lang-setup-" (ein:$kernelspec-language kernelspec))))
```
As white spaces are problematic and upper-case unusual, I propose to normalize the `language` string by replacing white spaces by hyphens and to lower-case the string.
