### PR TITLE
Forestall Polymode "Contamination"

### DIFF
--- a/test/test-ein-poly.el
+++ b/test/test-ein-poly.el
@@ -1,0 +1,10 @@
+(require 'ert)
+(require 'poly-ein)
+(require 'byte-compile)
+
+(ert-deftest ein:should-not-compile-advised ()
+  (should (ad-should-compile 'syntax-ppss nil))
+  (should (ad-should-compile 'syntax-propertize nil))
+  (poly-ein--decorate-functions)
+  (should-not (ad-should-compile 'syntax-ppss nil))
+  (should-not (ad-should-compile 'syntax-propertize nil)))


### PR DESCRIPTION
Hamfistedly set `ad-default-compilation-action` to `never` as soon as I advise an important global such as `syntax-ppss`.

Closes #537 