### PR TITLE
Polymode bugfixes

### DIFF
--- a/README.in.rst
+++ b/README.in.rst
@@ -72,7 +72,7 @@ Enable `polymode`_ via::
 
    M-x customize-group RET ein
    Toggle Ein:Polymode
-  
+
 ob-ein
 ======
 

--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Enable `polymode`_ via::
 
    M-x customize-group RET ein
    Toggle Ein:Polymode
-  
+
 ob-ein
 ======
 

--- a/features/polymode.feature
+++ b/features/polymode.feature
@@ -12,3 +12,27 @@ Scenario: selection spans cells
   Then newlined region should be "In [ ]:\n\n\nIn [ ]:\n"
   And I press "C-g"
   Then the region should not be active
+
+@poly
+Scenario: markdown often erroneously fontifies the whole buffer
+  Given new python notebook
+  And I press "C-c C-t"
+  And I type "# Header"
+  And I press "RET"
+  And I press "C-p"
+  And I press "C-p"
+  And I press "C-e"
+  Then text property at point includes "rear-nonsticky"
+
+@poly
+Scenario: moving cells requires refontification
+  Given new python notebook
+  And I press "C-c C-t"
+  And I type "# Header"
+  And I press "RET"
+  And I press "C-c C-b"
+  And I type "import math"
+  And I press "C-c C-c"
+  And I press "M-<up>"
+  And I press "C-<down>"
+  And I go to word "Header"

--- a/features/step-definitions/ein-steps.el
+++ b/features/step-definitions/ein-steps.el
@@ -476,3 +476,10 @@
 (When "I evaluate the python code \"\\(.+\\)\"$"
       (lambda (code-str)
         (ein:shared-output-eval-string nil code-str nil)))
+
+(When "^text property at point includes \"\\(.+\\)\"$"
+      (lambda (properties)
+        (should-not
+         (mapcan (lambda (prop)
+                   (not (get-text-property (point) (intern prop))))
+                 (split-string properties ",")))))

--- a/lisp/ein-notebook.el
+++ b/lisp/ein-notebook.el
@@ -685,26 +685,26 @@ This is equivalent to do ``C-c`` in the console program."
   (ein:worksheet-render ws)
   (with-current-buffer (ein:worksheet-buffer ws)
     (let (multilang-failed)
-     (if ein:polymode
-         (poly-ein-mode)
-       ;; Changing major mode here is super dangerous as it
-       ;; kill-all-local-variables.
-       ;; Our saviour has been `ein:deflocal' which applies 'permanent-local
-       ;; to variables assigned up to this point, but we ought not rely on it
-       (funcall (ein:notebook-choose-mode))
-       (ein:worksheet-reinstall-undo-hooks ws)
-       (condition-case err
-           (ein:aif (ein:$notebook-kernelspec notebook)
-                    (ein:ml-lang-setup it))
-         (error (ein:log 'error (error-message-string err))
-                (setq multilang-failed t))))
-     (unless multilang-failed
-       (ein:notebook-mode)
-       (ein:notebook--notification-setup notebook)
-       (ein:notebook-setup-kill-buffer-hook)
-       (setq ein:%notebook% notebook)
-       (when ein:polymode
-         (poly-ein-fontify-buffer notebook))))))
+      (if ein:polymode
+          (poly-ein-mode)
+        ;; Changing major mode here is super dangerous as it
+        ;; kill-all-local-variables.
+        ;; Our saviour has been `ein:deflocal' which applies 'permanent-local
+        ;; to variables assigned up to this point, but we ought not rely on it
+        (funcall (ein:notebook-choose-mode))
+        (ein:worksheet-reinstall-undo-hooks ws)
+        (condition-case err
+            (ein:aif (ein:$notebook-kernelspec notebook)
+                (ein:ml-lang-setup it))
+          (error (ein:log 'error (error-message-string err))
+                 (setq multilang-failed t))))
+      (unless multilang-failed
+        (ein:notebook-mode)
+        (ein:notebook--notification-setup notebook)
+        (ein:notebook-setup-kill-buffer-hook)
+        (setq ein:%notebook% notebook)
+        (when ein:polymode
+          (poly-ein-fontify-buffer (ein:notebook-buffer notebook)))))))
 
 (defun ein:notebook--notification-setup (notebook)
   (ein:notification-setup

--- a/lisp/ein-worksheet.el
+++ b/lisp/ein-worksheet.el
@@ -970,7 +970,9 @@ It is set in `ein:notebook-multilang-mode'."
         ;; (as opposed to ein:worksheet-insert-cell)
         (setq clone (ein:worksheet-insert-clone ws cell pivot-cell (if up "above" "below")))
         (ein:cell-goto clone)
-        (oset ws :dirty t))
+        (oset ws :dirty t)
+        (when pm/polymode
+          (poly-ein-fontify-buffer (ein:worksheet--get-buffer ein:%worksheet%))))
     (message "No %s cell" (if up "previous" "next"))))
 
 (defun ein:worksheet-move-cell-up (ws cell)

--- a/tools/install-R.sh
+++ b/tools/install-R.sh
@@ -17,8 +17,7 @@ if [ "x$TRAVIS_OS_NAME" = "xlinux" ] ; then
     R -e "install.packages('IRkernel', repos='http://cran.mirrors.hoobly.com')"
     R -e "IRkernel::installspec()"
 elif [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
-    brew update
-    brew list r &>/dev/null || brew install r
+    brew list r &>/dev/null || HOMEBREW_NO_AUTO_UPDATE=1 brew install r
     R -e "install.packages('IRkernel', repos='http://cran.mirrors.hoobly.com')"
     R -e "IRkernel::installspec()"
 fi

--- a/tools/install-julia.sh
+++ b/tools/install-julia.sh
@@ -16,8 +16,7 @@ if [ "x$TRAVIS_OS_NAME" = "xlinux" ] ; then
     julia --version
     julia -e 'import Pkg; Pkg.add("IJulia")'
 elif [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
-    brew update
-    brew cask list julia &>/dev/null || brew cask install julia
+    brew cask list julia &>/dev/null || HOMEBREW_NO_AUTO_UPDATE=1 brew cask install julia
     julia --version
     julia -e 'import Pkg; Pkg.add("IJulia")'
 fi

--- a/tools/install-julia.sh
+++ b/tools/install-julia.sh
@@ -16,6 +16,7 @@ if [ "x$TRAVIS_OS_NAME" = "xlinux" ] ; then
     julia --version
     julia -e 'import Pkg; Pkg.add("IJulia")'
 elif [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
+    brew update
     brew cask list julia &>/dev/null || HOMEBREW_NO_AUTO_UPDATE=1 brew cask install julia
     julia --version
     julia -e 'import Pkg; Pkg.add("IJulia")'

--- a/tools/install-virtualenv.sh
+++ b/tools/install-virtualenv.sh
@@ -9,7 +9,6 @@ WORKDIR=${HOME}/local
 . tools/retry.sh
 
 if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
-    brew update
     brew list pyenv-virtualenv || HOMEBREW_NO_AUTO_UPDATE=1 brew install pyenv-virtualenv
 
     case "${TOXENV}" in

--- a/tools/install-virtualenv.sh
+++ b/tools/install-virtualenv.sh
@@ -9,7 +9,7 @@ WORKDIR=${HOME}/local
 . tools/retry.sh
 
 if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
-    brew list pyenv-virtualenv || HOMEBREW_NO_AUTO_UPDATE=1 brew install pyenv-virtualenv
+    brew list pyenv-virtualenv &>/dev/null || HOMEBREW_NO_AUTO_UPDATE=1 brew install pyenv-virtualenv
 
     case "${TOXENV}" in
         py27)

--- a/tools/install-virtualenv.sh
+++ b/tools/install-virtualenv.sh
@@ -10,7 +10,7 @@ WORKDIR=${HOME}/local
 
 if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
     brew update
-    brew list pyenv-virtualenv || brew install pyenv-virtualenv
+    brew list pyenv-virtualenv || HOMEBREW_NO_AUTO_UPDATE=1 brew install pyenv-virtualenv
 
     case "${TOXENV}" in
         py27)


### PR DESCRIPTION
Because global-font-lock-mode will call font-lock-initial-fontify, the
inconsistency of [this polymode hack](https://github.com/polymode/polymode/blob/82a0c3d71cc02e32a347033b3f42afeac4e43f66/polymode-methods.el#L136-L140) nullifying font-lock-function while preserving
font-lock-fontify-buffer-function causes the whole buffer to get
fontified in polymode.

Commit a969736 duplicated the before-until advice on
syntax-propertize breaking polymode badly, and yet none of my
tests catch this (partly because it's hard to test font-lock).