### PR TITLE
tkf/emacs-request 0.3.1 defaults encoding to utf-8

### DIFF
--- a/lisp/ein-pkg.el
+++ b/lisp/ein-pkg.el
@@ -4,7 +4,7 @@
   '((emacs "25")
     (websocket "20190620.338")
     (auto-complete "1.4.0")
-    (request "0.3")
+    (request "20190621.1622")
     (deferred "0.5")
     (polymode "20190426.1729")
     (markdown-mode "20171116.756")

--- a/lisp/ein-query.el
+++ b/lisp/ein-query.el
@@ -88,6 +88,7 @@ aborts).  Instead you will see Race! in debug messages.
                                 (append (plist-get settings :headers)
                                         (list (cons "X-XSRFTOKEN" xsrf)))))
       (setf (gethash host ein:query-xsrf-cache) xsrf))
+    (setq settings (plist-put settings :encoding 'binary))
     settings))
 
 (defcustom ein:max-simultaneous-queries 100

--- a/test/test-ein-notebook.el
+++ b/test/test-ein-notebook.el
@@ -902,6 +902,14 @@ defined."
           (should (equal (assoc-default 'source (elt cells 0) #'eq) text)))
       (should (zerop (length cells))))))
 
+(ert-deftest ein:notebook-saves-latin ()
+  (with-current-buffer (ein:testing-notebook-make-new)
+    (let ((latin "«utf-8 cannot handle these»"))
+      ;; Edit notebook.
+      (ein:cell-goto (ein:get-cell-at-point))
+      (insert latin)
+      (should (ein:notebook-save-notebook (ein:get-notebook))))))
+
 (ert-deftest ein:notebook-to-json-after-closing-a-worksheet ()
   (with-current-buffer (ein:testing-notebook-make-new)
     (let ((buffer (current-buffer))


### PR DESCRIPTION
ein seems to have preferred the old default encoding of `binary` versus
`utf-8`.  Explicity set encoding back to `binary` but this
necessitates our using the latest emacs-request.

Fixes #566