### PR TITLE
Follow-up customizable default kernel; make ob-ein usable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,6 @@ install:
       pyenv activate $TOXENV ;
     fi
   - ${PIP} --upgrade pip
-  - ${PIP} wheel
   - ${PIP} wheel jupyter ipython\<=$IPYTHON jedi\<=0.13.3 ipykernel numpy\<=1.16.0 matplotlib\<=3.0.2
   - ${PY} -m ipykernel install --user
   - sh tools/install-R.sh

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test-compile: clean autoloads
 	cask clean-elc
 
 .PHONY: quick
-quick: test-compile test-unit
+quick: test-compile test-ob-ein-recurse test-unit
 
 .PHONY: test-jupyterhub
 test-jupyterhub: test-compile
@@ -85,6 +85,10 @@ test-int:
 .PHONY: test-unit
 test-unit:
 	cask exec ert-runner -L ./lisp -L ./test -l test/testein.el test/test-ein*.el
+
+.PHONY: test-ob-ein-recurse
+test-ob-ein-recurse:
+	cask eval "(progn (custom-set-variables (quote (org-babel-load-languages (quote ((emacs-lisp . t) (ein . t)))))) (org-version))"
 
 .PHONY: test-install
 test-install:

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -72,7 +72,7 @@
 
 (Setup
  (ein:dev-start-debug)
- (setq ein:notebooklist-default-kernel
+ (setq ein:jupyter-default-kernel
        (loop with cand = ""
              for (k . spec) in
              (alist-get

--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -49,26 +49,6 @@
   :type 'integer
 )
 
-(defcustom ein:notebooklist-default-kernel 'first-alphabetically
-  "With which of ${XDG_DATA_HOME}/jupyter/kernels to create new notebooks."
-  :group 'ein
-  :type (append
-         '(choice (other :tag "First alphabetically" first-alphabetically))
-         (condition-case nil
-             (mapcar
-              (lambda (x) `(const :tag ,(cdr x) ,(car x)))
-              (loop
-               for (k . spec) in
-               (alist-get
-                'kernelspecs
-                (let ((json-object-type 'alist))
-                  (json-read-from-string
-                   (shell-command-to-string
-                    (format "%s kernelspec list --json"
-                            ein:jupyter-default-server-command)))))
-               collect `(,k . ,(alist-get 'display_name (alist-get 'spec spec)))))
-           (error '((string :tag "Ask"))))))
-
 (defcustom ein:notebooklist-render-order
   '(render-header
     render-opened-notebooks
@@ -619,12 +599,12 @@ This function is called via `ein:notebook-after-rename-hook'."
             (widget-radio-add-item radio-widget (list 'item
                                                       :value (car k)
                                                       :format (format "%s\n" (cdr k)))))
-          (unless (eq ein:notebooklist-default-kernel 'first-alphabetically)
+          (unless (eq ein:jupyter-default-kernel 'first-alphabetically)
             (widget-radio-value-set
              radio-widget
-             (if (stringp ein:notebooklist-default-kernel)
-                 ein:notebooklist-default-kernel
-               (symbol-name ein:notebooklist-default-kernel))))
+             (if (stringp ein:jupyter-default-kernel)
+                 ein:jupyter-default-kernel
+               (symbol-name ein:jupyter-default-kernel))))
           (widget-insert "\n"))))))
 
 (defun render-opened-notebooks (url-or-port &rest args)


### PR DESCRIPTION
Relocate the defcustom for default kernel (cf #82) from ein-notebooklist to ein-jupyter (where the required `ein:jupyter-default-server-command` is defined).

Test that ob-ein doesn't cause recursion reported in #586 #588 

Fixes #586 #588 

