### PR TITLE
Osx nix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,13 @@ env:
 matrix:
   include:
     - os: linux
-      env: EMACS_CI=emacs-25-3 IPYTHON=5.8.0 PY=python PIP="${PY} -m pip install --user"
+      env: EMACS_CI=emacs-25-1 IPYTHON=5.8.0 PY=python PIP="${PY} -m pip install --user"
     - os: linux
       env: EMACS_CI=emacs-26-1 IPYTHON=6.5.0 PY=python3 PIP="${PY} -m pip install --user"
     - os: linux
       env: EMACS_CI=emacs-26-3 IPYTHON=7.8.0 PY=python3 PIP="${PY} -m pip install --user"
     - os: osx
-      language: generic
-      env: EVM_EMACS=emacs-25.2 IPYTHON=5.8.0 PY=python PIP="pip install" TOXENV=py27
+      env: EMACS_CI=emacs-25-2 IPYTHON=5.8.0 PY=python PIP="pip install" TOXENV=py27
 
   allow_failures:
     - env: EMACS_CI=emacs-snapshot
@@ -67,14 +66,7 @@ install:
   - ipython --version
 
 before_script:
-  - |
-    if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
-      sh tools/install-evm.sh
-      evm config path $HOME/.evm
-      evm install $EVM_EMACS --use --skip
-    else
-      bash <(curl https://raw.githubusercontent.com/purcell/nix-emacs-ci/master/travis-install)
-    fi
+  - bash <(curl https://raw.githubusercontent.com/purcell/nix-emacs-ci/master/travis-install)
   - emacs --version
   - sh tools/install-cask.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
     - os: linux
       env: EMACS_CI=emacs-26-1 IPYTHON=6.5.0 PY=python3 PIP="${PY} -m pip install --user"
     - os: linux
-      env: EMACS_CI=emacs-26-3 IPYTHON=7.8.0 PY=python3 PIP="${PY} -m pip install --user"
+      env: EMACS_CI=emacs-26-3 IPYTHON=7.5.0 PY=python3 PIP="${PY} -m pip install --user"
     - os: osx
       env: EMACS_CI=emacs-25-2 IPYTHON=5.8.0 PY=python PIP="pip install" TOXENV=py27
 

--- a/features/connect.feature
+++ b/features/connect.feature
@@ -13,9 +13,8 @@ Scenario: Company completion in a python buffer
   And I type "itertools."
   And I call "company-complete"
   And I wait for completions "itertools.chain"
-  And I press "C-g"
-  And I press "RET"
-  And I press "RET"
+  And I press "C-a"
+  And I press "C-k"
   And I clear websocket log
   And I type "itertool"
   And I call "company-complete"

--- a/features/notebooklist.feature
+++ b/features/notebooklist.feature
@@ -1,8 +1,7 @@
 @bread
 Scenario: Breadcrumbs
   Given I am in notebooklist buffer
-  When I click on dir "step-definitions"
-  Then I should see "ein-steps"
+  When I click on dir "step-definitions" until "ein-steps"
   And I click on "Home"
   Then I should see "support"
 

--- a/features/step-definitions/ein-steps.el
+++ b/features/step-definitions/ein-steps.el
@@ -313,6 +313,18 @@
           (loop until (not (equal was (widget-at)))
                 do (sleep-for 0 500)))))
 
+(When "^I click on dir \"\\(.+\\)\" until \"\\(.+\\)\"$"
+      (lambda (dir stop)
+        (loop repeat 10
+              until (search stop (buffer-string))
+              do (When (format "I go to word \"%s\"" dir))
+              do (re-search-backward "Dir" nil t)
+              do (let ((was (widget-at)))
+                   (When "I press \"RET\"")
+                   (loop until (not (equal was (widget-at)))
+                         do (sleep-for 0 500)))
+              finally do (should (search stop (buffer-string))))))
+
 (When "^old notebook \"\\(.+\\)\"$"
       (lambda (path)
         (lexical-let ((url-or-port (car (ein:jupyter-server-conn-info))) notebook)

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -72,6 +72,8 @@
 
 (Setup
  (ein:dev-start-debug)
+ (cl-assert (boundp 'company-frontends))
+ (custom-set-variables '(company-frontends nil))
  (setq ein:jupyter-default-kernel
        (loop with cand = ""
              for (k . spec) in

--- a/lisp/ein-completer.el
+++ b/lisp/ein-completer.el
@@ -92,10 +92,6 @@
 (defun ein:completions--reset-oinfo-cache (kernel)
   (setf (ein:$kernel-oinfo-cache kernel) (make-hash-table :test #'equal)))
 
-(defun ein:dev-clear-oinfo-cache (kernel)
-  (interactive (list (ein:get-kernel)))
-  (ein:completions--reset-oinfo-cache kernel))
-
 (defun ein:completions-get-cached (partial oinfo-cache)
   (loop for candidate being the hash-keys of oinfo-cache
         when (string-prefix-p partial candidate)

--- a/lisp/ein-connect.el
+++ b/lisp/ein-connect.el
@@ -174,7 +174,7 @@ notebooks."
   (interactive (list (ein:notebooklist-ask-path "notebook")))
   (multiple-value-bind (url-or-port path) (ein:notebooklist-parse-nbpath nbpath)
     (ein:notebook-open url-or-port path nil
-                       (apply-partially 
+                       (apply-partially
                         (lambda (buffer* no-reconnection* notebook created)
                           (ein:connect-buffer-to-notebook notebook buffer* no-reconnection*))
                         (or buffer (current-buffer)) no-reconnection))))
@@ -403,8 +403,10 @@ notebook."
      (define-key ein:connect-mode-map "." 'ein:ac-dot-complete)
      (auto-complete-mode))
     (ein:use-company-backend
-     (add-to-list 'company-backends #'ein:company-backend)
-     (company-mode))))
+     (if (not (boundp 'company-backends))
+         (error "ein:connect-mode: company unsupported")
+       (cl-assert (member 'ein:company-backend company-backends))
+       (company-mode)))))
 
 (put 'ein:connect-mode 'permanent-local t)
 

--- a/lisp/ein-multilang.el
+++ b/lisp/ein-multilang.el
@@ -32,13 +32,11 @@
 (require 'ein-worksheet)
 (require 'ein-multilang-fontify)
 (require 'python)
-(require 'ess-r-mode nil t)
-(require 'ess-custom nil t)
-(require 'julia-mode nil t)
 
 (declare-function ess-indent-line "ess")
 (declare-function ess-r-eldoc-function "ess-r-completion")
 (declare-function ess-setq-vars-local "ess-utils")
+(declare-function julia-indent-line "julia-mode")
 
 (defun ein:ml-fontify (limit)
   "Fontify next input area comes after the current point then
@@ -144,6 +142,7 @@ This function may raise an error."
   (set-keymap-parent ein:notebook-multilang-mode-map python-mode-map))
 
 (defun ein:ml-lang-setup-julia ()
+  (require 'julia-mode nil t)
   (when (featurep 'julia-mode)
     (setq-local mode-name "EIN[julia]")
     (setq-local comment-start "# ")
@@ -156,6 +155,8 @@ This function may raise an error."
       (set-keymap-parent ein:notebook-multilang-mode-map julia-mode-map))))
 
 (defun ein:ml-lang-setup-R ()
+  (require 'ess-r-mode nil t)
+  (require 'ess-custom nil t)
   (when (and (featurep 'ess-r-mode) (featurep 'ess-custom))
     (setq-local mode-name "EIN[R]")
     (when (boundp 'ess-r-customize-alist)

--- a/lisp/ein-notebook.el
+++ b/lisp/ein-notebook.el
@@ -1699,9 +1699,11 @@ watch the fireworks!"
        (ein:notebook--define-key ein:notebook-mode-map "." 'ein:notebook-ac-dot-complete)
        (auto-complete-mode))
       (ein:use-company-backend
-       (add-to-list 'company-backends 'ein:company-backend)
-       (ein:notebook--define-key ein:notebook-mode-map "." nil)
-       (company-mode)))
+       (if (not (boundp 'company-backends))
+           (error "ein:connect-mode: company unsupported")
+         (cl-assert (member 'ein:company-backend company-backends))
+         (ein:notebook--define-key ein:notebook-mode-map "." nil)
+         (company-mode))))
     (ein:aif ein:helm-kernel-history-search-key
         (ein:notebook--define-key ein:notebook-mode-map it 'helm-ein-kernel-history))
     (ein:aif ein:anything-kernel-history-search-key

--- a/lisp/ein-utils.el
+++ b/lisp/ein-utils.el
@@ -149,10 +149,9 @@ The result is unspecified if there isn't a symbol under the point."
   "Similar to `ein:object-at-point', but instead of returning the entire object
 only returns the string up to the current point. For example, given pd.Series, if the
 cursor is at the S then 'pd.S' will be returned."
-  (if (ein:object-at-point)
-      (let* ((obj (ein:object-at-point))
-             (delta (- (point) (ein:object-start-pos))))
-        (substring obj 0 delta))))
+  (ein:and-let* ((obj (ein:object-at-point))
+                 (delta (- (point) (ein:object-start-pos))))
+    (substring obj 0 delta)))
 
 (defun ein:object-at-point ()
   "Return dotty.words.at.point.


### PR DESCRIPTION
`company-backends' is special-variable-p so I don't believe it can be
buffer-local.

avoid eager loading of ess or julia.

if one changes the minimal tested version of emacs, one should `make
README` to reflect.  Also, reverted back to 25.1 because #509.

no need for evm under osx (purcell).

restore a completion test (after disabling company-frontends).

https://github.com/davidhalter/jedi/issues/1415 a python3 kernel and ipython7.8 reproducibly fails the auto-complete test.  Unclear how package maintainer "reset to success".