### PR TITLE
ein-completer: Use entire cell/buffer for completion context.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ quick: test-compile test-ob-ein-recurse test-unit
 test-jupyterhub: test-compile
 # jupyterhub slightly temperamental with json-readtable-error
 # seems to be affecting ob-ipython too but probably my bug.. just need to find it
-	-cask exec ecukes --tags @jupyterhub --reporter magnars
+	-cask exec ecukes --tags @jupyterhub,~@complete-ipy7 --reporter magnars
 
 .PHONY: test
 test: quick test-int test-poly
@@ -75,7 +75,7 @@ test: quick test-int test-poly
 test-poly:
 	cask exec ert-runner -L ./lisp -L ./test -l test/testfunc.el test/test-poly.el test/test-func.el
 	cp test/test-poly.el features/support/test-poly.el
-	cask exec ecukes --reporter magnars ; (ret=$$? ; rm -f features/support/test-poly.el && exit $$ret)
+	cask exec ecukes --reporter magnars --tags ~@complete-ipy7 ; (ret=$$? ; rm -f features/support/test-poly.el && exit $$ret)
 
 .PHONY: test-int
 test-int:

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ test-poly:
 .PHONY: test-int
 test-int:
 	cask exec ert-runner -L ./lisp -L ./test -l test/testfunc.el test/test-func.el
-	cask exec ecukes --reporter magnars --tags ~@poly-complete
+	cask exec ecukes --reporter magnars --tags ~@poly-complete,~@complete-ipy7
 
 .PHONY: test-unit
 test-unit:

--- a/features/notebook.feature
+++ b/features/notebook.feature
@@ -53,6 +53,23 @@ Scenario: company completion
   Given new python notebook
   Given I set "ein:completion-backend" to eval "(quote ein:use-none-backend)"
 
+@complete
+Scenario: company completion without execution
+  Given I set "ein:completion-backend" to eval "(quote ein:use-company-backend)"
+  Given I kill all websocket buffers
+  Given new python notebook
+  And I type "import itertools"
+  And I press "RET"
+  And I type "itertool"
+  And I call "company-complete"
+  Then I should see "itertools"
+  And I type ".chai"
+  And I call "company-complete"
+  Then I should see "itertools.chain"
+  Given I set "ein:completion-backend" to eval "(quote ein:use-ac-backend)"
+  Given new python notebook
+  Given I set "ein:completion-backend" to eval "(quote ein:use-none-backend)"
+
 @rename
 Scenario: rename notebook
   Given new python notebook

--- a/features/notebook.feature
+++ b/features/notebook.feature
@@ -53,7 +53,7 @@ Scenario: company completion
   Given new python notebook
   Given I set "ein:completion-backend" to eval "(quote ein:use-none-backend)"
 
-@complete
+@complete-ipy7
 Scenario: company completion without execution
   Given I set "ein:completion-backend" to eval "(quote ein:use-company-backend)"
   Given I kill all websocket buffers

--- a/lisp/ein-ipdb.el
+++ b/lisp/ein-ipdb.el
@@ -36,6 +36,16 @@
   kernel
   current-payload)
 
+(defun ein:ipbd ()
+  "Convenience function that will launch the ipython debugger,
+assuming there is an active kernel associated with the current
+buffer. For more information see the %debug magic documentation
+in ipython."
+  (interactive)
+  (ein:shared-output-eval-string (ein:get-kernel)
+                                 "%debug"
+                                 nil))
+
 (defun ein:find-or-create-ipdb-session (kernel &optional buffer)
   (ein:aif (gethash (ein:$kernel-kernel-id kernel) *ein:ipdb-sessions*)
       it


### PR DESCRIPTION
The modern Jupyter messaging spec (> 5.0) simplified `complete_request` to allow
sending blocks of text as completion context. EIN now takes advantage of this by
sending the entire contents of the worksheet cell, when in a notebook buffer,
or, when in a non-notebook buffer, the entire contents of the buffer. This
allows backends like jedi to do better context-sensitive completion without
having to execute code. In general this should improve completion behavior,
though may result in an initial performance hit when working in large buffers
while EIN builds the oinfo cache. Note that oinfo (i.e., function call
signatures) will not be available until code in the buffer/cell is executed.