### PR TITLE
Add commands to execute all cells above/below current one

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -306,7 +306,9 @@ created via `ein:notebook-create-checkpoint`.
    :replace: s/C-c TAB/C-c C-i/
              s/C-c RET/C-c C-m/
 
-.. el:function:: ein:worksheet-execute-all-cell
+.. el:function:: ein:worksheet-execute-all-cells
+.. el:function:: ein:worksheet-execute-all-cells-above
+.. el:function:: ein:worksheet-execute-all-cells-below
 .. el:function:: ein:worksheet-delete-cell
 .. el:function:: ein:junk-rename
 .. el:function:: ein:iexec-mode

--- a/features/execute-all-cells.feature
+++ b/features/execute-all-cells.feature
@@ -1,0 +1,52 @@
+@execute-all-cells
+Scenario: Execute all cells
+  Given new python notebook
+  And I type "2 ** 3"
+  And I press "C-c C-b"
+  And I type "2 ** 4"
+  And I press "C-c C-b"
+  And I type "2 ** 5"
+  And I press "C-c C-b"
+  And I type "2 ** 6"
+  When I call "ein:worksheet-execute-all-cells"
+  And I wait 1 second
+  Then I should see "8"
+  And I should see "16"
+  And I should see "32"
+  And I should see "64"
+
+@execute-all-cells
+Scenario: Execute all cells above
+  Given new python notebook
+  And I type "2 ** 3"
+  And I press "C-c C-b"
+  And I type "2 ** 4"
+  And I press "C-c C-b"
+  And I type "2 ** 5"
+  And I press "C-c C-b"
+  And I type "2 ** 6"
+  And I press "C-c C-p"
+  When I call "ein:worksheet-execute-all-cells-above"
+  And I wait 1 second
+  Then I should see "8"
+  And I should see "16"
+  And I should not see "32"
+  And I should not see "64"
+
+@execute-all-cells
+Scenario: Execute all cells below
+  Given new python notebook
+  And I type "2 ** 3"
+  And I press "C-c C-b"
+  And I type "2 ** 4"
+  And I press "C-c C-b"
+  And I type "2 ** 5"
+  And I press "C-c C-b"
+  And I type "2 ** 6"
+  And I press "C-c C-p"
+  When I call "ein:worksheet-execute-all-cells-below"
+  And I wait 1 second
+  Then I should not see "8"
+  And I should not see "16"
+  And I should see "32"
+  And I should see "64"

--- a/lisp/ein-notebook.el
+++ b/lisp/ein-notebook.el
@@ -1587,8 +1587,12 @@ Use simple `python-mode' based notebook mode when MuMaMo is not installed::
             ("Execute cell and insert below"
              ein:worksheet-execute-cell-and-insert-below
              :active (ein:worksheet-at-codecell-p))
-            ("Execute all"
-             ein:worksheet-execute-all-cell)
+            ("Execute all cells"
+             ein:worksheet-execute-all-cells)
+	    ("Execute all cells above"
+             ein:worksheet-execute-all-cells-above)
+	    ("Execute all cells below"
+             ein:worksheet-execute-all-cells-below)
             ("Turn on auto execution flag" ein:worksheet-turn-on-autoexec
              :active (ein:worksheet-at-codecell-p))
             ("Evaluate code in minibuffer" ein:shared-output-eval-string)


### PR DESCRIPTION
Given the exploratory nature of notebooks, I've been really missing this functionality from browser-based Jupyter, so here it goes (resolves #367).

And as for removing/obsoleting `ein:worksheet-execute-all-cell` - there are two reasons for this:
* naming inconsistency (all cell vs all cells);
* `mapc` is meant for side effects, which seems like a good fit here, _but_ it returns the original sequence, which is a bit problematic/annoying when you are in the `*scratch*` buffer, cooking something that involves EIN's circural data structures.