### PR TITLE
Reduce the number of oinfo calls.

### DIFF
--- a/features/pytools.feature
+++ b/features/pytools.feature
@@ -4,7 +4,7 @@ Scenario: Check that pytools are being loaded.
   And I type "__ein_pytools_version"
   And I press "M-RET"
   And I wait for the smoke to clear
-  Then I should see "1.0.0"
+  Then I should see "1.1.0"
 
 @pytools @matplotlib
 Scenario: Setting matplotlib figure size.

--- a/lisp/ein-pytools.el
+++ b/lisp/ein-pytools.el
@@ -452,7 +452,7 @@ Currently EIN/IPython supports exporting to the following formats:
          (in-height (/ (display-mm-height) 25.4)))
     (values (/ pixel-width in-width) (/ pixel-height in-height))))
 
-(defun ein:pytools-matplotlib-api-correction ()
+(defun ein:pytools-matplotlib-dpi-correction ()
   "Estimate the screen dpi and set the matplotlib rc parameter 'figure.dpi' to that value. Call this command *after* importing matplotlib into your notebook, else this setting will be overwritten after the first call to `import matplotlib' Further testing is needed to see how well this works on high resolution displays."
   (interactive)
   (multiple-value-bind (dpi-w dpi-h) (ein:pytools--estimate-screen-dpi)

--- a/lisp/ein_remote_safe.py
+++ b/lisp/ein_remote_safe.py
@@ -20,7 +20,7 @@ along with ein.py.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 
-__ein_pytools_version = "1.0.0"
+__ein_pytools_version = "1.1.0"
 
 try:
     from matplotlib import rc as __ein_rc
@@ -116,6 +116,16 @@ def __ein_run_docstring_examples(obj, verbose=True):
     return doctest.run_docstring_examples(obj, globs, verbose=verbose)
 
 
+def __ein_generate_oinfo_data(ostrings, locals=None):
+    import json
+
+    defined_objects = [__ein_maybe_undefined_object(obj, locals) for obj in ostrings
+                       if __ein_maybe_undefined_object(obj, locals) is not None]
+    odata = [__ein_object_info_for(obj) for obj in defined_objects]
+
+    print (json.dumps(odata))
+    return odata
+
 def __ein_maybe_undefined_object(obj, locals=None):
     try:
         return eval(obj, None, locals)
@@ -124,16 +134,15 @@ def __ein_maybe_undefined_object(obj, locals=None):
     except SyntaxError:
         return None
 
-def __ein_print_object_info_for(obj):
+def __ein_object_info_for(obj):
     import IPython.core.oinspect
-    import json
 
     inspector = IPython.core.oinspect.Inspector()
 
     try:
-        print(json.dumps(inspector.info(obj)))
+        return inspector.info(obj)
     except Exception:
-        print(json.dumps(inspector.info(None)))
+        return inspector.info(None)
 
 def __ein_eval_hy_string(obj):
     try:

--- a/lisp/ein_remote_safe.py
+++ b/lisp/ein_remote_safe.py
@@ -144,6 +144,13 @@ def __ein_object_info_for(obj):
     except Exception:
         return inspector.info(None)
 
+
+def __ein_print_object_info_for(obj):
+    import json
+
+    oinfo = __ein_object_info_for(obj)
+    print (json.dumps(oinfo))
+
 def __ein_eval_hy_string(obj):
     try:
         import hy

--- a/test/test_ein_remote.py
+++ b/test/test_ein_remote.py
@@ -1,0 +1,69 @@
+#
+import json
+import sys
+
+sys.path.append('lisp/')
+
+
+def test_undefined_object01():
+    from ein_remote_safe import __ein_maybe_undefined_object
+    # Set up some user variables
+    a = 1
+    b = "A string"
+    c = [1, 2, 3]
+    obj_a = __ein_maybe_undefined_object('a', locals=locals())
+    obj_b = __ein_maybe_undefined_object('b', locals=locals())
+    obj_c = __ein_maybe_undefined_object('c', locals=locals())
+    assert obj_a == a
+    assert obj_b == b
+    assert obj_c == c
+
+
+def test_undefined_object02():
+    from ein_remote_safe import __ein_maybe_undefined_object
+    # Test on objects that don't exist
+    obj_a = __ein_maybe_undefined_object('not_an_object', locals=locals())
+    assert obj_a == None
+
+
+def test_get_object_info01():
+    from ein_remote_safe import __ein_object_info_for
+    a = [1, 2, 3]
+    oinfo_a = __ein_object_info_for(a)
+    assert oinfo_a['type_name'] == "list"
+    assert oinfo_a['string_form'] == "[1, 2, 3]"
+
+
+def test_get_oinfo_from_string():
+    from ein_remote_safe import __ein_maybe_undefined_object, __ein_object_info_for
+    a = [1, 2,3 ]
+    oinfo_a = __ein_object_info_for(__ein_maybe_undefined_object('a', locals=locals()))
+    assert oinfo_a['type_name'] == "list"
+    assert oinfo_a['string_form'] == "[1, 2, 3]"
+
+
+def test_generate_oinfo_data01():
+    from ein_remote_safe import __ein_generate_oinfo_data
+    a = 1
+    b = "A string"
+    c = [1, 2, 3]
+    oinfos = __ein_generate_oinfo_data(['a', 'b', 'c'], locals=locals())
+    assert oinfos[0]['type_name'] == "int"
+    assert oinfos[1]['type_name'] == "str"
+    assert oinfos[2]['type_name'] == "list"
+
+
+def test_generate_oinfo_package01():
+    import heapq
+    from ein_remote_safe import __ein_generate_oinfo_data
+    oinfos = __ein_generate_oinfo_data(dir(heapq), locals=locals())
+    assert len(oinfos) == 8 # Not everything in the package will generate object info.
+    assert oinfos[0]['type_name'] == "dict"
+
+
+def test_generate_oinfo_package02():
+    import sys
+    from ein_remote_safe import __ein_generate_oinfo_data
+    oinfos = __ein_generate_oinfo_data(dir(sys), locals=locals())
+    assert len(oinfos) == 7
+    assert oinfos[0]['type_name'] == "str"


### PR DESCRIPTION
Notebook performance would noticeably suffer when doing completions in large
namespaces (I'm looking at you pandas) because it could result in many (100's)
of individual calls to `__ein_print_object_info_for'. This was very inefficient,
so now what the code does is make a single python call to generate oinfo results
for a list of completion candidates. Performance seems much improved, but only
time will tell if this is just my imagination or not.