### PR TITLE
Fixed issue where redirect checker was clobbering url

### DIFF
--- a/lisp/ein-contents-api.el
+++ b/lisp/ein-contents-api.el
@@ -131,8 +131,9 @@ global setting.  For global setting and more information, see
     (if (< (ein:notebook-version-numeric url-or-port) 3)
         (setq content (ein:new-content-legacy url-or-port path data))
       (setq content (ein:new-content url-or-port path data)))
-    (ein:aif response
-        (setf (ein:$content-url-or-port content) (ein:get-response-redirect it)))
+    (if (and response
+	     (> (length (request-response-history response)) 0))
+	(setf (ein:$content-url-or-port content) (ein:get-response-redirect it)))
     (when callback
       (funcall callback content))))
 

--- a/lisp/ein-contents-api.el
+++ b/lisp/ein-contents-api.el
@@ -133,7 +133,7 @@ global setting.  For global setting and more information, see
       (setq content (ein:new-content url-or-port path data)))
     (if (and response
 	     (> (length (request-response-history response)) 0))
-	(setf (ein:$content-url-or-port content) (ein:get-response-redirect it)))
+	(setf (ein:$content-url-or-port content) (ein:get-response-redirect response)))
     (when callback
       (funcall callback content))))
 

--- a/lisp/ein-query.el
+++ b/lisp/ein-query.el
@@ -157,12 +157,11 @@ KEY, then call `request' with URL and SETTINGS.  KEY is compared by
 
 (defun ein:get-response-redirect (response)
   "Determine if the query has been redirected, and if so return then URL the request was redirected to."
-  (if (length (request-response-history response))
       (let ((url (url-generic-parse-url (format "%s" (request-response-url response)))))
         (format "%s://%s:%s"
                 (url-type url)
                 (url-host url)
-                (url-port url)))))
+                (url-port url))))
 
 
 ;;; Cookie


### PR DESCRIPTION
I was experiencing an issue where I could not save files (not notebooks) on Jupiterhub servers. The problem was that on jupyterhub servers the url-or-port combo should look like `https://jupyterhub.example.com:8000/home/user` but for some reason the save function was clobbering the *home/user* part of the url yielding a http 405. I traced the issue down to the `ein:content-query-contents--success` function.

The logic here seems to be a bit wrong. If there is a response it calls `ein:get-response-redirect it` which has the conditional`(if (length (request-response-history response))`. I don't think this conditional will ever be false since `request-response-history` is a list according to the request.el documents and even if the length is 0 this evaluates to `t`. 

I don't know how the redirected requests look so I didn't modify the `ein:get-response-request` code except to remove the superfluous conditional. I also added what I /think/ the correct logic should be to the code that calls this code. This involved removing the `ein:aif` macro. I'm not super familiar with this code so I don't know if that macro is important.