### PR TITLE
Fix travis osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       env: EMACS_CI=emacs-26-3 IPYTHON=7.8.0 PY=python3 PIP="${PY} -m pip install --user"
     - os: osx
       language: generic
-      env: EVM_EMACS=emacs-25.2 IPYTHON=7.8.0 PY=python3 PIP="${PY} -m pip install" TOXENV=py37
+      env: EVM_EMACS=emacs-25.2 IPYTHON=5.8.0 PY=python3 PIP="${PY} -m pip install" TOXENV=py37
 
   allow_failures:
     - env: EMACS_CI=emacs-snapshot
@@ -63,7 +63,7 @@ install:
   - sh tools/install-R.sh
   - sh tools/install-julia.sh
   - hash -r
-  - jupyter kernelspec list
+  - ${PY} -m jupyter kernelspec list
   - curl --version
   - ipython --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       env: EMACS_CI=emacs-26-3 IPYTHON=7.8.0 PY=python3 PIP="${PY} -m pip install --user"
     - os: osx
       language: generic
-      env: EVM_EMACS=emacs-25.2 IPYTHON=6.5.0 PY=python3 PIP="${PY} -m pip install" TOXENV=py37
+      env: EVM_EMACS=emacs-25.2 IPYTHON=7.8.0 PY=python3 PIP="${PY} -m pip install" TOXENV=py37
 
   allow_failures:
     - env: EMACS_CI=emacs-snapshot
@@ -56,10 +56,9 @@ install:
       eval "$(pyenv init -)" ;
       pyenv activate $TOXENV ;
       pip install virtualenv ;
-      pip install prompt-toolkit==2.0.9 ;
     fi
   - ${PIP} --upgrade pip
-  - ${PIP} wheel jupyter ipython\<=$IPYTHON jedi\>=0.15.1 ipykernel numpy\<=1.16.0 matplotlib\<=3.0.2 epc
+  - ${PIP} wheel jupyter ipython\<=$IPYTHON jedi\>=0.15.1 numpy\<=1.16.0 matplotlib\<=3.0.2 epc
   - ${PY} -m ipykernel install --user
   - sh tools/install-R.sh
   - sh tools/install-julia.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       env: EMACS_CI=emacs-26-3 IPYTHON=7.8.0 PY=python3 PIP="${PY} -m pip install --user"
     - os: osx
       language: generic
-      env: EVM_EMACS=emacs-26.1 IPYTHON=5.8.0 PY=python3 PIP="${PY} -m pip install" TOXENV=py37
+      env: EVM_EMACS=emacs-26.3 IPYTHON=5.8.0 PY=python3 PIP="${PY} -m pip install" TOXENV=py37
 
   allow_failures:
     - env: EMACS_CI=emacs-snapshot
@@ -69,7 +69,6 @@ install:
 before_script:
   - |
     if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
-      brew install gpg
       sh tools/install-evm.sh
       evm config path $HOME/.evm
       evm install $EVM_EMACS --use --skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       env: EMACS_CI=emacs-26-3 IPYTHON=7.8.0 PY=python3 PIP="${PY} -m pip install --user"
     - os: osx
       language: generic
-      env: EVM_EMACS=emacs-25.2 IPYTHON=5.8.0 PY=python PIP="pip install" TOXENV=py27
+      env: EVM_EMACS=emacs-25.2 IPYTHON=5.8.0 PY=python3 PIP="${PY} -m pip install" TOXENV=py37
 
   allow_failures:
     - env: EMACS_CI=emacs-snapshot

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
   - sh tools/install-R.sh
   - sh tools/install-julia.sh
   - hash -r
-  - ${PY} -m jupyter kernelspec list
+  - jupyter kernelspec list
   - curl --version
   - ipython --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ install:
       eval "$(pyenv init -)" ;
       pyenv activate $TOXENV ;
       pip install virtualenv ;
+      pip install prompt-toolkit=2.0.9 ;
     fi
   - ${PIP} --upgrade pip
   - ${PIP} wheel jupyter ipython\<=$IPYTHON jedi\>=0.15.1 ipykernel numpy\<=1.16.0 matplotlib\<=3.0.2 epc

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ install:
 before_script:
   - |
     if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
+      brew install gpg
       sh tools/install-evm.sh
       evm config path $HOME/.evm
       evm install $EVM_EMACS --use --skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,6 @@ install:
   - sh tools/install-virtualenv.sh
   - |
     if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
-      eval "$(pyenv init -)" ;
       pyenv activate $TOXENV ;
       pip install virtualenv ;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       env: EMACS_CI=emacs-26-3 IPYTHON=7.8.0 PY=python3 PIP="${PY} -m pip install --user"
     - os: osx
       language: generic
-      env: EVM_EMACS=emacs-25.2 IPYTHON=5.8.0 PY=python3 PIP="${PY} -m pip install" TOXENV=py37
+      env: EVM_EMACS=emacs-25.2 IPYTHON=6.5.0 PY=python3 PIP="${PY} -m pip install" TOXENV=py37
 
   allow_failures:
     - env: EMACS_CI=emacs-snapshot

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
       eval "$(pyenv init -)" ;
       pyenv activate $TOXENV ;
       pip install virtualenv ;
-      pip install prompt-toolkit=2.0.9 ;
+      pip install prompt-toolkit==2.0.9 ;
     fi
   - ${PIP} --upgrade pip
   - ${PIP} wheel jupyter ipython\<=$IPYTHON jedi\>=0.15.1 ipykernel numpy\<=1.16.0 matplotlib\<=3.0.2 epc

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       env: EMACS_CI=emacs-26-3 IPYTHON=7.8.0 PY=python3 PIP="${PY} -m pip install --user"
     - os: osx
       language: generic
-      env: EVM_EMACS=emacs-25.2 IPYTHON=5.8.0 PY=python3 PIP="${PY} -m pip install" TOXENV=py37
+      env: EVM_EMACS=emacs-26.1 IPYTHON=5.8.0 PY=python3 PIP="${PY} -m pip install" TOXENV=py37
 
   allow_failures:
     - env: EMACS_CI=emacs-snapshot

--- a/tools/install-virtualenv.sh
+++ b/tools/install-virtualenv.sh
@@ -12,7 +12,6 @@ if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
     brew list pyenv-virtualenv &>/dev/null || HOMEBREW_NO_AUTO_UPDATE=1 brew install pyenv-virtualenv
     eval "$(pyenv init -)"
     eval "$(pyenv virtualenv-init -)"
-    exec "$SHELL"
 
     case "${TOXENV}" in
         py27)

--- a/tools/install-virtualenv.sh
+++ b/tools/install-virtualenv.sh
@@ -25,8 +25,8 @@ if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
             pyenv virtualenv -f 3.6.9 py36
             ;;
         py37)
-            pyenv install -s 3.7.6
-            pyenv virtualenv -f 3.7.6 py37
+            pyenv install -s 3.7.5
+            pyenv virtualenv -f 3.7.5 py37
             ;;
     esac
 fi

--- a/tools/install-virtualenv.sh
+++ b/tools/install-virtualenv.sh
@@ -10,8 +10,9 @@ WORKDIR=${HOME}/local
 
 if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
     brew list pyenv-virtualenv &>/dev/null || HOMEBREW_NO_AUTO_UPDATE=1 brew install pyenv-virtualenv
-    eval "$(pyenv init -)" ;
+    eval "$(pyenv init -)"
     eval "$(pyenv virtualenv-init -)"
+    exec "$SHELL"
 
     case "${TOXENV}" in
         py27)

--- a/tools/install-virtualenv.sh
+++ b/tools/install-virtualenv.sh
@@ -25,7 +25,8 @@ if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
             pyenv virtualenv -f 3.6.9 py36
             ;;
         py37)
-            pyenv install -s 3.7.5
-            pyenv virtualenv -f 3.7.5 py37
+            pyenv install -s 3.7.6
+            pyenv virtualenv -f 3.7.6 py37
+            ;;
     esac
 fi

--- a/tools/install-virtualenv.sh
+++ b/tools/install-virtualenv.sh
@@ -10,6 +10,8 @@ WORKDIR=${HOME}/local
 
 if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
     brew list pyenv-virtualenv &>/dev/null || HOMEBREW_NO_AUTO_UPDATE=1 brew install pyenv-virtualenv
+    eval "$(pyenv init -)" ;
+    eval "$(pyenv virtualenv-init -)"
 
     case "${TOXENV}" in
         py27)
@@ -28,8 +30,6 @@ if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
             pyenv install -s 3.7.5
             pyenv virtualenv -f 3.7.5 py37
             pyenv rehash
-            pyenv global 3.7.5
-            pyenv version
             ;;
     esac
 fi

--- a/tools/install-virtualenv.sh
+++ b/tools/install-virtualenv.sh
@@ -27,6 +27,9 @@ if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
         py37)
             pyenv install -s 3.7.5
             pyenv virtualenv -f 3.7.5 py37
+            pyenv rehash
+            pyenv global 3.7.5
+            pyenv version
             ;;
     esac
 fi


### PR DESCRIPTION
The OS X build on travis decided to suddenly have problems with python27 and with elpa package signing in emacs. In response the OS X build now tests against python 3.7 and emacs 26.3. Since python 2.7 is now nearly at end-of-life my conscience is relatively clear on upgrading the python version, plus we still have the linux python 2.7 build to test against. Going to emacs 26.3 may not be so easily justified, but again we still have a linux build that tests against emacs 25.1.