### PR TITLE
Execute oinfo requests only when kernel is python.

### DIFF
--- a/lisp/ein-cell-edit.el
+++ b/lisp/ein-cell-edit.el
@@ -168,9 +168,10 @@ previous value."
 (defun ein:get-mode-for-kernel (kernelspec)
   (if (null kernelspec)
       'python ;; FIXME
-    (ein:case-equal (ein:$kernelspec-language kernelspec)
-      (("julia" "python" "R") (intern (ein:$kernelspec-language kernelspec)))
-      (t 'python))))
+    (intern (ein:$kernelspec-language kernelspec))))
+    ;; (ein:case-equal (ein:$kernelspec-language kernelspec)
+    ;;   (("julia" "python" "R") )
+    ;;   (t 'python))))
 
 (defun ein:edit-src-continue (e)
   (interactive "e")

--- a/lisp/ein-completer.el
+++ b/lisp/ein-completer.el
@@ -115,13 +115,15 @@
 (defun ein:completions--get-oinfo (objs)
   (let ((d (deferred:new #'identity))
         (kernel (ein:get-kernel)))
-    (if (ein:kernel-live-p kernel)
-        (ein:kernel-execute
-         kernel
-         (format "__ein_generate_oinfo_data(%s, locals())" objs)
-         (list
-          :output `(,(lambda (d* &rest args) (deferred:callback-post d* args)) . ,d)))
-      (deferred:callback-post d "kernel not live"))
+    (ein:case-equal (ein:kernel-language kernel)
+      (("python")
+       (if (ein:kernel-live-p kernel)
+           (ein:kernel-execute
+            kernel
+            (format "__ein_generate_oinfo_data(%s, locals())" objs)
+            (list
+             :output `(,(lambda (d* &rest args) (deferred:callback-post d* args)) . ,d)))
+         (deferred:callback-post d "kernel not live"))))
     d))
 
 (defvar ein:oinfo-chunk-size 50)

--- a/lisp/ein-kernel.el
+++ b/lisp/ein-kernel.el
@@ -85,6 +85,9 @@
   "Destructor for `ein:$kernel'."
   (ein:kernel-disconnect kernel))
 
+(defun ein:kernel-language (kernel)
+  "Return a string naming the language used by kernel `kernel'. Typical return values might be 'python', or 'julia', or 'R' (among others)."
+  (ein:$kernelspec-language (ein:$kernel-kernelspec kernel)))
 
 (defun ein:kernel--get-msg (kernel msg-type content)
   (list


### PR DESCRIPTION
Otherwise we will try to execute python code in a non-python environment. This
doesn't break anythng, but can fill the log with many, many errors.

In the future might be interesting to add language-dependent methods of
generating object information.