### PR TITLE
Correctly process ansi color codes in text output. Multilang haskell.

### DIFF
--- a/Cask
+++ b/Cask
@@ -23,6 +23,7 @@
  (depends-on "markdown-mode")
  (depends-on "clojure-mode")
  (depends-on "julia-mode")
+ (depends-on "haskell-mode")
  (depends-on "undo-tree")
  (depends-on "ess")
  (depends-on "px")

--- a/lisp/ein-cell.el
+++ b/lisp/ein-cell.el
@@ -1015,7 +1015,7 @@ prettified text thus be used instead of HTML type."
         ((html text/html)
          (funcall (ein:output-area-get-html-renderer) (plist-get json type)))
         ((latex text/latex text text/plain)
-         (ein:insert-read-only (plist-get json type)))
+         (ein:insert-read-only (ansi-color-apply (plist-get json type))))
         ((svg image/svg+xml)
          (ein:insert-image value (ein:fix-mime-type key) t))
         ((png image/png jpeg image/jpeg)

--- a/lisp/ein-multilang.el
+++ b/lisp/ein-multilang.el
@@ -35,6 +35,7 @@
 (require 'ess-custom nil t)
 (require 'clojure-mode nil t)
 (require 'julia-mode nil t)
+(require 'haskell-mode nil t)
 
 (declare-function ess-indent-line "ess")
 (declare-function ess-r-eldoc-function "ess-r-completion")
@@ -187,6 +188,18 @@ This function may raise an error."
       (set-syntax-table ess-r-mode-syntax-table))
     (when (boundp 'ess-r-mode-map)
       (set-keymap-parent ein:notebook-multilang-mode-map ess-r-mode-map))))
+
+(defun ein:ml-lang-setup-haskell ()
+  (when (featurep 'haskell-mode)
+    (setq-local mode-name "EIN[haskell]")
+    (setq-local comment-start "-- ")
+    ;; (setq-local comment-start-skip  "--\\s-*")
+    (setq-local indent-line-function
+                (apply-partially #'ein:ml-indent-line-function #'haskell-indentation-indent-line))
+    (when (boundp 'haskell-mode-syntax-table)
+      (set-syntax-table haskell-mode-syntax-table))
+    (when (boundp 'haskell-mode-map)
+      (set-keymap-parent ein:notebook-multilang-mode-map haskell-mode-map))))
 
 (defun ein:ml-lang-setup (kernelspec)
   (let ((setup-func (intern (concat "ein:ml-lang-setup-" (ein:$kernelspec-language kernelspec)))))

--- a/lisp/ein-multilang.el
+++ b/lisp/ein-multilang.el
@@ -40,6 +40,7 @@
 (declare-function ess-indent-line "ess")
 (declare-function ess-r-eldoc-function "ess-r-completion")
 (declare-function ess-setq-vars-local "ess-utils")
+(declare-function haskell-indentation-indent-line "haskell-indentation")
 
 (defun ein:ml-fontify (limit)
   "Fontify next input area comes after the current point then
@@ -194,8 +195,9 @@ This function may raise an error."
     (setq-local mode-name "EIN[haskell]")
     (setq-local comment-start "-- ")
     ;; (setq-local comment-start-skip  "--\\s-*")
-    (setq-local indent-line-function
-                (apply-partially #'ein:ml-indent-line-function #'haskell-indentation-indent-line))
+    (when (boundp 'haskell-indentation-indent-line)
+      (setq-local indent-line-function
+                  (apply-partially #'ein:ml-indent-line-function #'haskell-indentation-indent-line)))
     (when (boundp 'haskell-mode-syntax-table)
       (set-syntax-table haskell-mode-syntax-table))
     (when (boundp 'haskell-mode-map)


### PR DESCRIPTION
Caught this while testing julia support.

Bonus change: add multilang support for Haskell.