### PR TITLE
reassert ignorance of redirects

### DIFF
--- a/features/notebooklist.feature
+++ b/features/notebooklist.feature
@@ -55,11 +55,13 @@ Scenario: Delete closes buffers and sessions
   And I clear log expr "ein:log-all-buffer-name"
   And I click on "Delete"
   And I wait for buffer to not say "Untitled"
+  And I dump buffer
   Then eval "(should-not (ein:notebook-opened-notebooks)))"
   Then eval "(should-not (seq-some (lambda (b) (cl-search "Untitled" (buffer-name b))) (buffer-list)))"
   And I switch to log expr "ein:log-all-buffer-name"
-  And I wait for buffer to say "kernel-delete-session--success"
-  And I wait for buffer to say "notebooklist-delete-notebook--complete"
+  And I dump buffer
+  Then I should see "kernel-delete-session--success"
+  Then I should see "notebooklist-delete-notebook--complete"
 
 @content
 Scenario: Read a massive directory

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -70,7 +70,7 @@
             for path = (ein:$notebook-notebook-path nb)
             do (ein:log 'debug "Notebook %s still open" path)
             finally do (assert nil)))
-  (cl-loop repeat 5
+  (cl-loop repeat 30
            for stragglers = (file-name-all-completions "Untitled"
                                                        ein:testing-jupyter-server-root)
            until (null stragglers)

--- a/lisp/ein-contents-api.el
+++ b/lisp/ein-contents-api.el
@@ -106,10 +106,6 @@ ERRBACK of arity 1 for the contents."
                (ein:log 'error notice)
                (when errback (funcall errback url-or-port status-code)))))))))
 
-
-;; TODO: This is one place to check for redirects - update the url slot if so.
-;; Will need to pass the response object and check either request-response-history
-;; or request-response-url.
 (cl-defun ein:content-query-contents--success (url-or-port path callback
                                                &key data symbol-status response
                                                &allow-other-keys)
@@ -117,8 +113,6 @@ ERRBACK of arity 1 for the contents."
     (if (< (ein:notebook-version-numeric url-or-port) 3)
         (setq content (ein:new-content-legacy url-or-port path data))
       (setq content (ein:new-content url-or-port path data)))
-    (aif response
-        (setf (ein:$content-url-or-port content) (ein:get-response-redirect it)))
     (when callback
       (funcall callback content))))
 

--- a/lisp/ein-query.el
+++ b/lisp/ein-query.el
@@ -122,15 +122,6 @@ aborts).  Instead you will see Race! in debug messages.
   (setq settings (plist-put settings :sync ein:force-sync))
   (apply #'request (url-encode-url url) (ein:query-prepare-header url settings)))
 
-(defun ein:get-response-redirect (response)
-  "Determine if the query has been redirected, and if so return then URL the request was redirected to."
-  (if (length (request-response-history response))
-      (let ((url (url-generic-parse-url (format "%s" (request-response-url response)))))
-        (format "%s://%s:%s"
-                (url-type url)
-                (url-host url)
-                (url-port url)))))
-
 ;;; Cookie
 
 (defalias 'ein:query-get-cookie 'request-cookie-string)


### PR DESCRIPTION
As the reasons for the redirect seem to be lost in time, and as
@noonker points out in #635 the redirect logic wasn't correct and
stymied file saves, we retry removing the redirect as initially suggested in #370.