### PR TITLE
Run custom hooks after a kernel connection is made.

### DIFF
--- a/features/notebook.feature
+++ b/features/notebook.feature
@@ -112,3 +112,11 @@ Scenario: Test the undo-tree-incompatible logic
   Given new python notebook
   And I call "turn-on-undo-tree-mode"
   Then the value of "undo-tree-mode" is nil
+
+@kernel-on-connect
+Scenario: Test ein:on-kernel-connect-functions abnormal hooks
+  Given I set the kernel connect message
+  Given new python notebook
+  And I wait for the smoke to clear
+  And I switch to buffer "*Messages*"
+  Then I should see "Hello ein."

--- a/features/step-definitions/ein-steps.el
+++ b/features/step-definitions/ein-steps.el
@@ -2,6 +2,10 @@
       (lambda ()
         (insert-char 37)))
 
+(When "^I set the kernel connect message$"
+      (lambda ()
+        (add-to-list 'ein:on-kernel-connect-functions #'(lambda (_) (message "Hello ein.")))))
+
 (When "^I type session port \\([0-9]+\\)$"
       (lambda (port)
         (ein:process-refresh-processes)


### PR DESCRIPTION
Introduce new user custom variable `ein:on-kernel-connect-functions' which is an
abnormal hook called after a kernel connection is made. All functions in the
hook are called with the connected kernel as an argument.

This replaces the old, unused `ein:kernel-run-after-start-hook' function.