### PR TITLE
Change pytools-request-help to C-c C-S-h

### DIFF
--- a/lisp/ein-notebook.el
+++ b/lisp/ein-notebook.el
@@ -1140,7 +1140,7 @@ Tried add-function: the &rest from :around is an emacs-25 compilation issue."
   (ein:notebook--define-key map (kbd "C-c <down>") ein:worksheet-move-cell-down)
   (ein:notebook--define-key map (kbd "M-<up>") ein:worksheet-not-move-cell-up)
   (ein:notebook--define-key map (kbd "M-<down>") ein:worksheet-not-move-cell-down)
-  (ein:notebook--define-key map "\C-c\C-h" ein:pytools-request-help)
+  (ein:notebook--define-key map "\C-c\C-S-h" ein:pytools-request-help)
   (ein:notebook--define-key map (kbd "C-c C-$") ein:tb-show)
   (ein:notebook--define-key map "\C-c\C-x" nil)
   (ein:notebook--define-key map "\C-c\C-x\C-r" ein:notebook-restart-session-command)


### PR DESCRIPTION
Stops keybinding to interfere with emacs default behaviour. That is, showing keybindings starting, for example, with C-x when pressing C-x C-h. Also better with which-key paging.