### PR TITLE
Keep the original #+RESULTS: block keywords after generating new results.

### DIFF
--- a/lisp/ob-ein.el
+++ b/lisp/ob-ein.el
@@ -270,7 +270,7 @@ The callback returns t if results containt RESULT-TYPE outputs, nil otherwise."
                         (wrong-number-of-arguments (org-babel-remove-result info))))
                    (condition-case nil
                        (org-babel-remove-result nil t)
-                     (wrong-number-of-arguments org-babel-remove-result)) ;; kill #+RESULTS: name
+                     (wrong-number-of-arguments (org-babel-remove-result))) ;; kill #+RESULTS: name
 		   (org-babel-insert-result
 		    result
 		    (cdr (assoc :result-params

--- a/lisp/ob-ein.el
+++ b/lisp/ob-ein.el
@@ -234,7 +234,10 @@ e.g., ob-c++ is not ob-C.el."
                   (ob-ein--process-outputs result-type
 					   (ein:shared-output-get-cell)
 					   processed-params))))
-      (org-babel-remove-result nil t)
+
+      (condition-case nil
+        (org-babel-remove-result nil t)
+        (error (org-babel-remove-result)));; kill #+RESULTS: name
       *ob-ein-sentinel*)))
 
 (defun ob-ein--execute-async-callback (buffer params result-type result-params name)
@@ -262,8 +265,12 @@ The callback returns t if results containt RESULT-TYPE outputs, nil otherwise."
 		 (unless (stringp (org-babel-goto-named-src-block name*)) ;; stringp=error
 		   (when info ;; kill #+RESULTS: (no-name)
 		     (setf (nth 4 info) nil)
-		     (org-babel-remove-result info t))
-		   (org-babel-remove-result nil t) ;; kill #+RESULTS: name
+                     (condition-case nil
+                         (org-babel-remove-result info t)
+                        (error (org-babel-remove-result info))))
+                   (condition-case nil
+                       (org-babel-remove-result nil t)
+                     (error org-babel-remove-result)) ;; kill #+RESULTS: name
 		   (org-babel-insert-result
 		    result
 		    (cdr (assoc :result-params
@@ -282,8 +289,12 @@ The callback returns t if results containt RESULT-TYPE outputs, nil otherwise."
 	     (unless (stringp (org-babel-goto-named-src-block name*)) ;; stringp=error
 	       (when info ;; kill #+RESULTS: (no-name)
 		 (setf (nth 4 info) nil)
-		 (org-babel-remove-result info t))
-	       (org-babel-remove-result nil t) ;; kill #+RESULTS: name
+                 (condition-case nil
+                     (org-babel-remove-result info t)
+                   (error (org-babel-remove-result info))))
+               (condition-case nil
+                   (org-babel-remove-result nil t)
+                 (error (org-babel-remove-result)));; kill #+RESULTS: name
 	       (org-babel-insert-result "" result-params*)
 	       (org-redisplay-inline-images)))))))
    buffer result-params name))

--- a/lisp/ob-ein.el
+++ b/lisp/ob-ein.el
@@ -234,7 +234,7 @@ e.g., ob-c++ is not ob-C.el."
                   (ob-ein--process-outputs result-type
 					   (ein:shared-output-get-cell)
 					   processed-params))))
-      (org-babel-remove-result)
+      (org-babel-remove-result nil t)
       *ob-ein-sentinel*)))
 
 (defun ob-ein--execute-async-callback (buffer params result-type result-params name)
@@ -262,8 +262,8 @@ The callback returns t if results containt RESULT-TYPE outputs, nil otherwise."
 		 (unless (stringp (org-babel-goto-named-src-block name*)) ;; stringp=error
 		   (when info ;; kill #+RESULTS: (no-name)
 		     (setf (nth 4 info) nil)
-		     (org-babel-remove-result info))
-		   (org-babel-remove-result) ;; kill #+RESULTS: name
+		     (org-babel-remove-result info t))
+		   (org-babel-remove-result nil t) ;; kill #+RESULTS: name
 		   (org-babel-insert-result
 		    result
 		    (cdr (assoc :result-params
@@ -282,8 +282,8 @@ The callback returns t if results containt RESULT-TYPE outputs, nil otherwise."
 	     (unless (stringp (org-babel-goto-named-src-block name*)) ;; stringp=error
 	       (when info ;; kill #+RESULTS: (no-name)
 		 (setf (nth 4 info) nil)
-		 (org-babel-remove-result info))
-	       (org-babel-remove-result) ;; kill #+RESULTS: name
+		 (org-babel-remove-result info t))
+	       (org-babel-remove-result nil t) ;; kill #+RESULTS: name
 	       (org-babel-insert-result "" result-params*)
 	       (org-redisplay-inline-images)))))))
    buffer result-params name))

--- a/lisp/ob-ein.el
+++ b/lisp/ob-ein.el
@@ -236,8 +236,8 @@ e.g., ob-c++ is not ob-C.el."
 					   processed-params))))
 
       (condition-case nil
-        (org-babel-remove-result nil t)
-        (error (org-babel-remove-result)));; kill #+RESULTS: name
+          (org-babel-remove-result nil t)
+        (wrong-number-of-arguments (org-babel-remove-result)));; kill #+RESULTS: name
       *ob-ein-sentinel*)))
 
 (defun ob-ein--execute-async-callback (buffer params result-type result-params name)
@@ -267,10 +267,10 @@ The callback returns t if results containt RESULT-TYPE outputs, nil otherwise."
 		     (setf (nth 4 info) nil)
                      (condition-case nil
                          (org-babel-remove-result info t)
-                        (error (org-babel-remove-result info))))
+                        (wrong-number-of-arguments (org-babel-remove-result info))))
                    (condition-case nil
                        (org-babel-remove-result nil t)
-                     (error org-babel-remove-result)) ;; kill #+RESULTS: name
+                     (wrong-number-of-arguments org-babel-remove-result)) ;; kill #+RESULTS: name
 		   (org-babel-insert-result
 		    result
 		    (cdr (assoc :result-params
@@ -291,10 +291,10 @@ The callback returns t if results containt RESULT-TYPE outputs, nil otherwise."
 		 (setf (nth 4 info) nil)
                  (condition-case nil
                      (org-babel-remove-result info t)
-                   (error (org-babel-remove-result info))))
+                   (wrong-number-of-arguments (org-babel-remove-result info))))
                (condition-case nil
                    (org-babel-remove-result nil t)
-                 (error (org-babel-remove-result)));; kill #+RESULTS: name
+                 (wrong-number-of-arguments (org-babel-remove-result)));; kill #+RESULTS: name
 	       (org-babel-insert-result "" result-params*)
 	       (org-redisplay-inline-images)))))))
    buffer result-params name))


### PR DESCRIPTION
Originally, when running ob-ein, I always had this annoying problem that it kept replacing my `#+NAME` and `#+CAPTION` keywords. 

For example, this is the original results block.
```
#+name: bottom-up dynamic programming approach-results
#+caption: bottom-up dynamic programming approach-results
#+RESULTS: bottom-up dynamic programming approach
#+begin_src none
8
#+end_src
```
After executing the src block again, I'd get this result:
```
#+RESULTS: bottom-up dynamic programming approach
#+begin_src none
8
#+end_src

#+name: bottom-up dynamic programming approach-results
#+caption: bottom-up dynamic programming approach-results
```

This PR fixes the problem by set the `KEEP-KEYWORD` in `org-babel-remove-result` to `t`.
Now when I run the code, it always gives me:
```
#+name: bottom-up dynamic programming approach-results
#+caption: bottom-up dynamic programming approach-results
#+RESULTS: bottom-up dynamic programming approach
#+begin_src none
8
#+end_src
```
