### PR TITLE
avoid "Warning: ‘oset’ is an obsolete macro (as of 28.1)"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 doc/build/
 .cask/*
 *.pyc
+*.elc
 log/*
 *.zip
 .gitattributes

--- a/lisp/ein-notebook.el
+++ b/lisp/ein-notebook.el
@@ -519,7 +519,7 @@ This is equivalent to do ``C-c`` in the console program."
   (let* ((cells (plist-get data :cells))
          (ws-cells (mapcar (lambda (data) (ein:cell-from-json data)) cells))
          (worksheet (ein:notebook--worksheet-new notebook)))
-    (oset worksheet :saved-cells ws-cells)
+    (setf (oref worksheet :saved-cells) ws-cells)
     ;(mapcar (lambda (data) (message "test %s" (slot-value data 'metadata))) ws-cells)
     (list worksheet)))
 

--- a/lisp/ein-notification.el
+++ b/lisp/ein-notification.el
@@ -92,7 +92,7 @@ where NS is `:kernel' or `:notebook' slot of NOTIFICATION."
     (ein:notification-status-set ns status)))
 
 (defun ein:notification--set-execution-count (notification count)
-  (oset notification :execution-count count))
+  (setf (oref notification :execution-count) count))
 
 (defun ein:notification--fadeout-callback (packed data)
   ;; FIXME: I can simplify this.
@@ -101,8 +101,8 @@ where NS is `:kernel' or `:notebook' slot of NOTIFICATION."
         (message (nth 1 packed))
         (status (nth 2 packed))
         (next (nth 3 packed)))
-    (oset ns :status status)
-    (oset ns :message message)
+    (setf (oref ns :status) status)
+    (setf (oref ns :message) message)
     (apply #'run-at-time
            1 nil
            (lambda (ns message status next)
@@ -149,7 +149,7 @@ insert-prev insert-next move-prev move-next)"
                          :buffer buffer))
     (setq header-line-format ein:header-line-format)
     (ein:notification-bind-events ein:%notification% events)
-    (oset ein:%notification% :tab
+    (setf (oref ein:%notification% :tab)
           (apply #'make-instance 'ein:notification-tab tab-slots))
     ein:%notification%))
 

--- a/lisp/ein-worksheet.el
+++ b/lisp/ein-worksheet.el
@@ -647,7 +647,7 @@ If you really want use this command, you can do something like this
     (apply #'ewoc-delete
            (slot-value ws 'ewoc)
            (ein:cell-all-element cell)))
-  (oset ws :dirty t)
+  (setf (oref ws :dirty) t)
   (when focus (ein:worksheet-focus-cell)))
 
 (defun ein:worksheet-kill-cell (ws cells &optional focus)
@@ -745,7 +745,7 @@ after PIVOT and return the new cell."
          "PIVOT is `nil' but ncells != 0.  There is something wrong...")))
     (ein:worksheet--unshift-undo-list cell (- (ein:cell-input-pos-max cell)
                                               (ein:cell-input-pos-min cell)))
-    (oset ws :dirty t)
+    (setf (oref ws :dirty) t)
     (when focus (ein:cell-goto cell))
     cell))
 
@@ -770,7 +770,7 @@ See also: `ein:worksheet-insert-cell-below'."
          "PIVOT is `nil' but ncells > 0.  There is something wrong...")))
     (ein:worksheet--unshift-undo-list cell (- (ein:cell-input-pos-max cell)
                                               (ein:cell-input-pos-min cell)))
-    (oset ws :dirty t)
+    (setf (oref ws :dirty) t)
     (when focus (ein:cell-goto cell))
     cell))
 
@@ -1046,7 +1046,7 @@ Do not clear input prompts when the prefix argument is given."
                               (?a (ein:worksheet-execute-all-cells ws* :above cell*))
                               (?b (ein:worksheet-execute-all-cells ws* :below cell*))
                               (t (ein:cell-execute cell*)
-                                 (oset ws* :dirty t)
+                                 (setf (oref ws* :dirty) t)
                                  (ein:worksheet--unshift-undo-list cell*))))
                           ws cell batch))
   cell)


### PR DESCRIPTION
trivial tweak