### PR TITLE
Add support for JupyterHub servers using an API token

### DIFF
--- a/lisp/ein-kernel.el
+++ b/lisp/ein-kernel.el
@@ -274,10 +274,10 @@ See https://github.com/ipython/ipython/pull/3307"
 
 (defun ein:start-single-websocket (kernel open-callback)
   "OPEN-CALLBACK (kernel) (e.g., execute cell)"
-  (let ((ws-url (concat (ein:$kernel-ws-url kernel)
-                         (ein:$kernel-kernel-url kernel)
-                         "/channels?session_id="
-                         (ein:$kernel-session-id kernel))))
+  (let ((ws-url (ein:url-join (ein:$kernel-ws-url kernel)
+			      (ein:$kernel-kernel-url kernel)
+			      (concat "/channels?session_id="
+				      (ein:$kernel-session-id kernel)))))
     (ein:log 'verbose "WS start: %s" ws-url)
     (setf (ein:$kernel-websocket kernel)
           (ein:websocket ws-url kernel

--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -694,12 +694,12 @@ and the url-or-port argument of ein:notebooklist-open*."
              (ein:notebooklist-login--error-1 url-or-port error-thrown response errback)
            (setq token (read-passwd (format "Password for %s: " url-or-port)))
            (ein:notebooklist-login--iteration url-or-port callback errback token (1+ iteration) response-status)))
-        ((request-response-header response "x-jupyterhub-version")
+        ((and (not (string-match-p "\\?" url-or-port)) (request-response-header response "x-jupyterhub-version"))
 	 (ein:notebooklist-login--error
 	  url-or-port token callback errback iteration
 	  :data data
 	  :response response
-	  :error-thrown '(error . ("Jupyterhub unsupported"))))
+	  :error-thrown '(error . ("Jupyterhub unsupported without token"))))
         (t (ein:notebooklist-login--success-1 url-or-port callback errback))))
 
 (cl-defun ein:notebooklist-login--error


### PR DESCRIPTION
With this change, JupyterHub servers can be used with a URL ending in `/user/$name/?token=$token` (with a token from `/hub/token`).

Note that I use `string-join` which is an Emacs 25 feature; if this needs to be compatible further back, that will need to be swapped out.