### PR TITLE
Refine regex expression when checking API version

### DIFF
--- a/lisp/ein-query.el
+++ b/lisp/ein-query.el
@@ -169,7 +169,7 @@ get (\"hub.data8x.berkeley.edu\" . \"806b3e7\")"
    (ein:url url-or-port "api/spec.yaml")
    ;; the melpa yaml package was taking too long, unfortunately
    :parser (lambda ()
-	     (if (re-search-forward "notebook api\\s-+version: \\(\\S-+\\)"
+	     (if (re-search-forward "api\\s-+version: \\(\\S-+\\)"
 				    nil t)
 		 ;; emacs-25.3 doesn't have the right string-trim
 		 (string-remove-prefix


### PR DESCRIPTION
I tried several different versions of jupyter lab, and found there're 2 different descriptions: `description: Server API` and `description: Notebook API`
 
See https://github.com/jupyter/notebook/blob/master/notebook/services/api/api.yaml#L1-L5
And https://github.com/jupyter-server/jupyter_server/blob/master/jupyter_server/services/api/api.yaml#L1-L5

So refine the regex expression to accommodate it.