### PR TITLE
try math-preview-at-point in markdown cells

### DIFF
--- a/lisp/ein-worksheet.el
+++ b/lisp/ein-worksheet.el
@@ -1054,7 +1054,9 @@ Do not clear input prompts when the prefix argument is given."
 		  (setf (oref ws* :dirty) t)
 		  (ein:worksheet--unshift-undo-list cell*))))
 	   ws cell batch)))
-	((ein:markdowncell-p cell) (progn (math-preview-at-point) (message "trying math-preview-at-point")))
+	((ein:markdowncell-p cell)
+         (when (fboundp 'math-preview-at-point)
+           (math-preview-at-point)))
       (t (message "ein:worksheet-execute-cell: not a code cell"))))
 
 (defun ein:worksheet-execute-cell-and-goto-next (ws cell &optional insert)

--- a/lisp/ein-worksheet.el
+++ b/lisp/ein-worksheet.el
@@ -1041,21 +1041,21 @@ Do not clear input prompts when the prefix argument is given."
                  ,(when current-prefix-arg
                     (prog1 (read-char-choice "[RET]all [a]bove [b]elow: " (list ?\r ?a ?b))
                       (message "")))))
-  (if (ein:codecell-p cell)
-      (ein:kernel-when-ready
-       (slot-value ws 'kernel)
-       (apply-partially
-        (lambda (ws* cell* batch* _kernel)
-          (cl-case batch*
-            (?\r (ein:worksheet-execute-all-cells ws*))
-            (?a (ein:worksheet-execute-all-cells ws* :above cell*))
-            (?b (ein:worksheet-execute-all-cells ws* :below cell*))
-            (t (ein:cell-execute cell*)
-               (setf (oref ws* :dirty) t)
-               (ein:worksheet--unshift-undo-list cell*))))
-        ws cell batch))
-    (message "ein:worksheet-execute-cell: not a code cell"))
-  cell)
+  (cond ((ein:codecell-p cell)
+	 (ein:kernel-when-ready
+	  (slot-value ws 'kernel)
+	  (apply-partially
+	   (lambda (ws* cell* batch* _kernel)
+	     (cl-case batch*
+	       (?\r (ein:worksheet-execute-all-cells ws*))
+	       (?a (ein:worksheet-execute-all-cells ws* :above cell*))
+	       (?b (ein:worksheet-execute-all-cells ws* :below cell*))
+	       (t (ein:cell-execute cell*)
+		  (setf (oref ws* :dirty) t)
+		  (ein:worksheet--unshift-undo-list cell*))))
+	   ws cell batch)))
+	((ein:markdowncell-p cell) (progn (math-preview-at-point) (message "trying math-preview-at-point")))
+      (t (message "ein:worksheet-execute-cell: not a code cell"))))
 
 (defun ein:worksheet-execute-cell-and-goto-next (ws cell &optional insert)
   "Execute cell at point if it is a code cell and move to the


### PR DESCRIPTION
ein:worksheet-execute-cell will try `math-preview-at-point` when invoked in a ein:markdowncell mode and print a message. The behavior is unchanged on other cell types.

In case of latex errors, they are correctly displayed in the minibuffer.