### PR TITLE
ein:jupyter-crib-token: check that the process is actually jupyter (#867)

### DIFF
--- a/lisp/ein-gat.el
+++ b/lisp/ein-gat.el
@@ -627,8 +627,7 @@ EOF
         (default (or (car ein:gat-preemptible-history) "n")))
     (ein:completing-read
      (format "%s [%s]: " kind default)
-     (split-string "y n")
-     nil t nil
+     '("y" "n") nil t nil
      'ein:gat-preemptible-history default)))
 
 (defun ein:gat-elicit-keyname ()

--- a/lisp/ein-jupyter.el
+++ b/lisp/ein-jupyter.el
@@ -259,7 +259,7 @@ of (PASSWORD TOKEN)."
                with token0
                with password0
                when (cl-destructuring-bind
-                        (&key password url token notebook_dir pid &allow-other-keys)
+                        (&key password url token pid &allow-other-keys)
                         (ein:json-read-from-string line)
                       (prog1 (and (equal (ein:url url) url-or-port)
                                   (let ((pal (process-attributes pid)))


### PR DESCRIPTION
This will avoid the persistent `401 unauthorized` error when there is a process with the same PID as an older jupyter.