### PR TITLE
Modified `ein:jupyter-server-use-subcommand` to be a list.

### DIFF
--- a/README.in.rst
+++ b/README.in.rst
@@ -37,7 +37,7 @@ Then
 
 Alternatively, directly clone this repo and ``make install``.
 
-For jupyterlab 3.0+, reconfigure the subcommand from "notebook" to "server".
+For jupyterlab 3.0+, reconfigure the subcommand from `'("notebook")` to `'("server")`.
 
 ::
 

--- a/lisp/ein-jupyter.el
+++ b/lisp/ein-jupyter.el
@@ -186,7 +186,7 @@ with `kubectl exec'."
                                 ein:jupyter-docker-additional-switches
                                 ein:jupyter-docker-image)))
                       (t
-                       (append (aif ein:jupyter-server-use-subcommand it)
+                       (append ein:jupyter-server-use-subcommand
                                (when dir
                                  (list (format "--notebook-dir=%s"
                                                (convert-standard-filename dir))))

--- a/lisp/ein-jupyter.el
+++ b/lisp/ein-jupyter.el
@@ -88,11 +88,11 @@ Changing this to `jupyter-notebook' requires customizing
          (set-default 'ein:jupyter-server-command value)))
 
 ;;;###autoload
-(defcustom ein:jupyter-server-use-subcommand "notebook"
+(defcustom ein:jupyter-server-use-subcommand '("notebook")
   "For JupyterLab 3.0+ change the subcommand to \"server\".
 Users of \"jupyter-notebook\" (as opposed to \"jupyter notebook\") select Omit."
   :group 'ein
-  :type '(choice (string :tag "Subcommand" "notebook")
+  :type '(choice (repeat :tag "Subcommands" (string))
                  (const :tag "Omit" nil)))
 
 (defcustom ein:jupyter-server-args '("--no-browser")
@@ -186,7 +186,7 @@ with `kubectl exec'."
                                 ein:jupyter-docker-additional-switches
                                 ein:jupyter-docker-image)))
                       (t
-                       (append (aif ein:jupyter-server-use-subcommand (list it))
+                       (append (aif ein:jupyter-server-use-subcommand it)
                                (when dir
                                  (list (format "--notebook-dir=%s"
                                                (convert-standard-filename dir))))
@@ -257,11 +257,9 @@ of (PASSWORD TOKEN)."
   (aif (cl-loop for line in
                 (apply #'ein:jupyter-process-lines url-or-port
                        ein:jupyter-server-command
-                       (split-string
-                        (format "%s%s %s"
-                                (aif ein:jupyter-server-use-subcommand
-                                    (concat it " ") "")
-                                "list" "--json")))
+                       (append
+                        ein:jupyter-server-use-subcommand
+                        '("list" "--json")))
                 with token0
                 with password0
                 when (cl-destructuring-bind
@@ -279,11 +277,9 @@ of (PASSWORD TOKEN)."
   (cl-loop for line in
            (apply #'ein:jupyter-process-lines nil
                   ein:jupyter-server-command
-                  (split-string
-                   (format "%s%s %s"
-                           (aif ein:jupyter-server-use-subcommand
-                               (concat it " ") "")
-                           "list" "--json")))
+                  (append
+                   ein:jupyter-server-use-subcommand
+                   '("list" "--json")))
            collecting (ein:json-read-from-string line)))
 
 ;;;###autoload

--- a/lisp/ein-process.el
+++ b/lisp/ein-process.el
@@ -123,8 +123,7 @@ Supply ERROR-BUFFER to capture stderr."
   (cl-loop for line in (condition-case err
                            (apply #'process-lines
                                   ein:jupyter-server-command
-                                  (append (aif ein:jupyter-server-use-subcommand
-                                              (list it))
+                                  (append ein:jupyter-server-use-subcommand
                                           '("list" "--json")))
                          ;; often there is no local jupyter installation
                          (error (ein:log 'info "ein:process-refresh-processes: %s" err) nil))


### PR DESCRIPTION
This allows using more complex subcommands. For example, launching jupyter from poetry can be done
by setting `ein:jupyter-server-command` to "poetry" and `ein:jupyter-server-use-subcommand to
`'("run" "jupyter" "lab")`.
